### PR TITLE
feat: add llms-txt-generator and inline-svg-architecture-diagrams skills

### DIFF
--- a/skills/custom/inline-svg-architecture-diagrams/SKILL.md
+++ b/skills/custom/inline-svg-architecture-diagrams/SKILL.md
@@ -1,0 +1,562 @@
+---
+name: inline-svg-architecture-diagrams
+description: Generate production-quality inline SVG architecture diagrams with theme-aware CSS variables, animated flow lines, glow effects, feedback loops, and responsive layout. No external dependencies, no build steps, no image files. Use when creating system architecture visuals that integrate with a design system.
+license: Complete terms in LICENSE.txt
+---
+
+# Inline SVG Architecture Diagrams
+
+> Create production-quality inline SVG architecture diagrams that integrate with any design system. No external dependencies, no build steps, no image files.
+
+## TL;DR Execution Flow
+
+```
+Phase 0: Gather inputs (layers, connections, feedback loops, external I/O, theme vars)
+Phase 1: Compute layout (positions, spacing, viewBox)
+Phase 2: Generate SVG foundation (defs: filters, gradients, grid pattern)
+Phase 3: Render layers (rectangles, labels, mini-icons, highlight treatment)
+Phase 4: Render connections (flow lines with animated dashes, arrowheads)
+Phase 5: Render feedback loops (curved return paths with reverse animation)
+Phase 6: Render external I/O (dashed boundary lines with labels)
+Phase 7: Wrap in container with hover styles and caption
+```
+
+## When to Use
+
+- Architecture diagrams that live in the page design (not external images)
+- System diagrams that must respect light/dark mode automatically
+- Any diagram where animated flow lines convey data direction
+- Situations where Mermaid/D2/Excalidraw look too generic or don't integrate with the design system
+
+## When NOT to Use
+
+- Simple box-and-arrow diagrams (Mermaid is fine)
+- Diagrams that need to be editable by non-developers (use Figma/Excalidraw)
+- Charts/graphs with data (use a charting library)
+
+## Inputs
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `layers` | Layer[] | Yes | Ordered list of layer/node definitions |
+| `connections` | Connection[] | Yes | Flow lines between layers |
+| `feedback_loops` | FeedbackLoop[] | No | Return paths (e.g., bottom layer back to top) |
+| `external_io` | ExternalIO[] | No | Inputs/outputs at system boundaries |
+| `theme_vars` | ThemeVars | No | CSS custom property names (has sensible defaults) |
+| `viewbox` | {w, h} | No | ViewBox dimensions (auto-calculated from layer count if omitted) |
+| `highlight_layer` | string | No | Layer ID to highlight with glow + pulse |
+
+### Layer Definition
+
+```yaml
+- id: knowledge
+  label: "01 · KNOWLEDGE"
+  title: "qortex"
+  output_label: "→ rules"        # optional right-side annotation
+  icon: knowledge-graph           # see Icon Reference below
+  link: "https://..."             # optional clickable link
+```
+
+### Connection Definition
+
+```yaml
+- from: knowledge
+  to: learning
+  label_left: "projects"          # left-side label
+  label_right: "rules"            # right-side label
+  direction: down                 # down | up | lateral
+```
+
+### Feedback Loop Definition
+
+```yaml
+- from: interoception
+  to: learning
+  label: "feedback"
+  side: left                      # which side the curve routes through
+```
+
+### External I/O Definition
+
+```yaml
+- target: nervous-system
+  side: left                      # left = input, right = output
+  labels: ["external", "signals"]
+```
+
+---
+
+## Phase 1: Layout Computation
+
+### Vertical Stack Layout
+
+```
+Layer spacing:
+  layer_height = 60
+  gap = 40 (between layers, includes connection line space)
+  margin_top = 20
+  margin_bottom = 20
+
+  layer_y(i) = margin_top + i * (layer_height + gap)
+
+  viewbox_height = margin_top + n * layer_height + (n-1) * gap + margin_bottom
+
+Layer positioning:
+  layer_width = 260
+  layer_x = (viewbox_width - layer_width) / 2
+
+  Default viewbox_width = 600
+```
+
+### Space Reservations
+
+```
+If feedback_loops exist on left:   reserve 110px left margin
+If external_io on left:            reserve 110px left margin (overlaps with above)
+If external_io on right:           reserve 110px right margin
+If neither:                        center layers in viewbox
+```
+
+---
+
+## Phase 2: SVG Foundation
+
+### 2.1 Filter Definitions
+
+**Standard Glow** — For highlighted layer border:
+
+```xml
+<filter id="glow">
+  <feGaussianBlur stdDeviation="2" result="blur"/>
+  <feMerge>
+    <feMergeNode in="blur"/>
+    <feMergeNode in="SourceGraphic"/>
+  </feMerge>
+</filter>
+```
+
+**Pulse Glow** — For animated emphasis ring:
+
+```xml
+<filter id="pulse-glow">
+  <feGaussianBlur stdDeviation="3" result="blur"/>
+  <feMerge>
+    <feMergeNode in="blur"/>
+    <feMergeNode in="SourceGraphic"/>
+  </feMerge>
+</filter>
+```
+
+### 2.2 Gradient Definitions
+
+```xml
+<!-- Downward flow: accent at top, transparent at bottom -->
+<linearGradient id="flow-down" x1="0" y1="0" x2="0" y2="1">
+  <stop offset="0%" stop-color="var(--color-accent)" stop-opacity="0.6"/>
+  <stop offset="100%" stop-color="var(--color-accent)" stop-opacity="0.1"/>
+</linearGradient>
+
+<!-- Upward flow: accent at bottom, transparent at top -->
+<linearGradient id="flow-up" x1="0" y1="1" x2="0" y2="0">
+  <stop offset="0%" stop-color="var(--color-accent)" stop-opacity="0.6"/>
+  <stop offset="100%" stop-color="var(--color-accent)" stop-opacity="0.1"/>
+</linearGradient>
+
+<!-- Rightward flow: transparent at left, accent at right -->
+<linearGradient id="flow-right" x1="0" y1="0" x2="1" y2="0">
+  <stop offset="0%" stop-color="var(--color-accent)" stop-opacity="0.1"/>
+  <stop offset="100%" stop-color="var(--color-accent)" stop-opacity="0.6"/>
+</linearGradient>
+```
+
+### 2.3 Background Grid Pattern
+
+```xml
+<pattern id="grid" width="30" height="30" patternUnits="userSpaceOnUse">
+  <path d="M 30 0 L 0 0 0 30" fill="none"
+        stroke="var(--color-border-subtle)" stroke-width="0.5" opacity="0.3"/>
+</pattern>
+
+<!-- Apply as first element after defs -->
+<rect width="100%" height="100%" fill="url(#grid)" opacity="0.5"/>
+```
+
+---
+
+## Phase 3: Render Layers
+
+### 3.1 Standard Layer
+
+```xml
+<g data-layer="{id}">
+  <!-- Background rect -->
+  <rect x="{x}" y="{y}" width="{w}" height="{h}" rx="8"
+        fill="var(--color-bg)" stroke="var(--color-border)" stroke-width="1"/>
+
+  <!-- Mini-icon (left side, see Icon Reference) -->
+  {icon_svg}
+
+  <!-- Layer number + label (top-left, small) -->
+  <text x="{x+30}" y="{y+18}" font-family="var(--font-mono)" font-size="9"
+        fill="var(--color-text-faint)" text-transform="uppercase" letter-spacing="0.05em">
+    {label}
+  </text>
+
+  <!-- Title (center-left, larger) -->
+  <text x="{x+30}" y="{y+42}" font-family="var(--font-sans)" font-size="14"
+        fill="var(--color-text)">
+    {title}
+  </text>
+
+  <!-- Output annotation (right side, small) -->
+  <text x="{x+w-10}" y="{y+42}" font-family="var(--font-mono)" font-size="8"
+        fill="var(--color-text-faint)" text-anchor="end" opacity="0.5">
+    {output_label}
+  </text>
+</g>
+```
+
+### 3.2 Highlighted Layer (active/core)
+
+Add these extras to the standard layer:
+
+```xml
+<!-- Accent border instead of standard -->
+<rect ... stroke="var(--color-accent)" stroke-width="2" filter="url(#glow)"/>
+
+<!-- Pulse ring (animated opacity) -->
+<rect x="{x}" y="{y}" width="{w}" height="{h}" rx="8"
+      fill="none" stroke="var(--color-accent)" stroke-width="0.5" opacity="0.3">
+  <animate attributeName="opacity" values="0.3;0.1;0.3" dur="3s" repeatCount="indefinite"/>
+</rect>
+
+<!-- "← core" marker (right side) -->
+<text x="{x+w+8}" y="{y+h/2+4}" font-family="var(--font-mono)" font-size="8"
+      fill="var(--color-accent)" opacity="0.5">← core</text>
+```
+
+### 3.3 Clickable Layer (with link)
+
+Wrap in an anchor with hover class:
+
+```xml
+<a href="{link}" class="layer-link">
+  <g data-layer="{id}">
+    <!-- rect gets class="layer-rect" for hover targeting -->
+    <rect class="layer-rect" .../>
+    ...
+  </g>
+</a>
+```
+
+---
+
+## Phase 4: Render Connections
+
+### 4.1 Downward Flow Line
+
+Between consecutive layers:
+
+```xml
+<g>
+  <!-- The line -->
+  <line x1="{center_x}" y1="{from_y + from_h}" x2="{center_x}" y2="{to_y}"
+        stroke="url(#flow-down)" stroke-width="1.5" stroke-dasharray="4 3">
+    <animate attributeName="stroke-dashoffset" from="0" to="-14" dur="2s" repeatCount="indefinite"/>
+  </line>
+
+  <!-- Arrowhead at target -->
+  <polygon points="{cx},{to_y-4} {cx-4},{to_y+2} {cx+4},{to_y+2}"
+           fill="var(--color-accent)" opacity="0.4"/>
+
+  <!-- Left label -->
+  <text x="{center_x - 8}" y="{midpoint_y}" font-size="8"
+        fill="var(--color-text-faint)" text-anchor="end" opacity="0.4">
+    {label_left}
+  </text>
+
+  <!-- Right label -->
+  <text x="{center_x + 8}" y="{midpoint_y}" font-size="8"
+        fill="var(--color-text-faint)" opacity="0.4">
+    {label_right}
+  </text>
+</g>
+```
+
+### 4.2 Animation Direction
+
+| Direction | `stroke-dashoffset` from→to | Visual effect |
+|-----------|---------------------------|---------------|
+| Down | `0` → `-14` | Dashes march downward |
+| Up | `0` → `14` | Dashes march upward |
+| Right | `0` → `-14` | Dashes march rightward |
+| Left | `0` → `14` | Dashes march leftward |
+
+The key: **negative offset = forward march, positive offset = reverse march**.
+
+Dash pattern `4 3` with offset `14` (= 2 × (4+3)) gives smooth looping.
+
+---
+
+## Phase 5: Render Feedback Loops
+
+### 5.1 Left-Side Return Path
+
+Routes outside the layer stack, up the left side:
+
+```xml
+<g>
+  <!-- Path: exit from layer left, go left, go up, enter target layer left -->
+  <path d="M {from_x} {from_cy} L {left_margin} {from_cy} L {left_margin} {to_cy} L {to_x} {to_cy}"
+        fill="none" stroke="var(--color-accent)" stroke-width="1.5"
+        stroke-dasharray="4 3" opacity="0.5">
+    <animate attributeName="stroke-dashoffset" from="0" to="14" dur="3s" repeatCount="indefinite"/>
+  </path>
+
+  <!-- Arrowhead at target -->
+  <polygon points="{to_x},{to_cy-4} {to_x-6},{to_cy} {to_x},{to_cy+4}"
+           fill="var(--color-accent)" opacity="0.5"/>
+
+  <!-- Vertical label (rotated -90°) -->
+  <text x="{left_margin - 8}" y="{midpoint_y}" font-size="8"
+        fill="var(--color-accent)" opacity="0.4" text-anchor="middle"
+        transform="rotate(-90, {left_margin - 8}, {midpoint_y})">
+    {label} ↑ feedback
+  </text>
+</g>
+```
+
+### 5.2 Animation: Reverse Direction
+
+Feedback loops use **positive** stroke-dashoffset (`0` → `14`) to visually convey upstream/return flow. This contrasts with the downward flows (`0` → `-14`), making the feedback direction immediately obvious.
+
+Slower duration (`3s` vs `2s`) further distinguishes feedback from forward flow.
+
+---
+
+## Phase 6: Render External I/O
+
+### 6.1 Input Arrow (Left Side)
+
+```xml
+<g>
+  <line x1="{left_edge}" y1="{target_cy}" x2="{target_x}" y2="{target_cy}"
+        stroke="var(--color-accent)" stroke-width="1" stroke-dasharray="3 2" opacity="0.4"/>
+
+  <polygon points="{target_x},{target_cy-3} {target_x-5},{target_cy} {target_x},{target_cy+3}"
+           fill="var(--color-accent)" opacity="0.4"/>
+
+  <!-- Stacked labels -->
+  <text x="{left_edge - 5}" y="{target_cy - 6}" font-size="8"
+        fill="var(--color-text-faint)" text-anchor="end" opacity="0.4">{labels[0]}</text>
+  <text x="{left_edge - 5}" y="{target_cy + 6}" font-size="8"
+        fill="var(--color-text-faint)" text-anchor="end" opacity="0.4">{labels[1]}</text>
+</g>
+```
+
+### 6.2 Output Arrow (Right Side)
+
+```xml
+<g>
+  <line x1="{target_x + target_w}" y1="{target_cy}" x2="{right_edge}" y2="{target_cy}"
+        stroke="var(--color-accent)" stroke-width="1" stroke-dasharray="3 2" opacity="0.4"/>
+
+  <polygon points="{right_edge},{target_cy-3} {right_edge+5},{target_cy} {right_edge},{target_cy+3}"
+           fill="var(--color-accent)" opacity="0.4"/>
+
+  <!-- Stacked labels -->
+  <text x="{right_edge + 10}" y="{target_cy - 8}" font-size="8"
+        fill="var(--color-text-faint)" opacity="0.4">{labels[0]}</text>
+  <text x="{right_edge + 10}" y="{target_cy + 2}" font-size="8"
+        fill="var(--color-text-faint)" opacity="0.4">{labels[1]}</text>
+  <!-- ... more stacked labels as needed -->
+</g>
+```
+
+---
+
+## Phase 7: Container & Hover Styles
+
+### 7.1 Container HTML
+
+```html
+<div class="system-diagram relative overflow-hidden rounded-lg border"
+     style="background: var(--color-bg-elevated); border-color: var(--color-border);">
+  <div class="p-4 sm:p-8">
+    <svg viewBox="0 0 {vb_w} {vb_h}" class="w-full h-auto"
+         aria-label="{description}">
+      <defs>...</defs>
+      <!-- grid, layers, connections, loops, I/O -->
+    </svg>
+  </div>
+  <p class="text-center text-sm pb-4" style="color: var(--color-text-muted);">
+    {caption}
+  </p>
+</div>
+```
+
+### 7.2 Hover CSS
+
+```css
+.layer-link:hover .layer-rect {
+  stroke: var(--color-accent);
+  stroke-width: 2;
+  transition: stroke 0.2s ease, stroke-width 0.2s ease;
+}
+
+.layer-link:hover text[font-size="14"],
+.layer-link:hover text[font-size="13"] {
+  fill: var(--color-accent);
+}
+
+.layer-link-text:hover {
+  opacity: 1 !important;
+  text-decoration: underline;
+}
+```
+
+---
+
+## Icon Reference
+
+Mini-icons are placed inside each layer rect at `(x+12, cy)`. All use `var(--color-accent)` with reduced opacity.
+
+### knowledge-graph
+Three interconnected dots forming a triangle:
+```xml
+<circle cx="{ix}" cy="{iy-4}" r="2" fill="var(--color-accent)" opacity="0.8"/>
+<circle cx="{ix+8}" cy="{iy-4}" r="2" fill="var(--color-accent)" opacity="0.8"/>
+<circle cx="{ix+4}" cy="{iy+4}" r="2" fill="var(--color-accent)" opacity="0.8"/>
+<line x1="{ix}" y1="{iy-4}" x2="{ix+8}" y2="{iy-4}" stroke="var(--color-accent)" stroke-width="0.7" opacity="0.5"/>
+<line x1="{ix}" y1="{iy-4}" x2="{ix+4}" y2="{iy+4}" stroke="var(--color-accent)" stroke-width="0.7" opacity="0.5"/>
+<line x1="{ix+8}" y1="{iy-4}" x2="{ix+4}" y2="{iy+4}" stroke="var(--color-accent)" stroke-width="0.7" opacity="0.5"/>
+```
+
+### beta-curve
+Stylized beta distribution curve:
+```xml
+<path d="M {ix-5} {iy+2} Q {ix-1} {iy-13}, {ix+4} {iy-5} Q {ix+9} {iy+5}, {ix+13} {iy+2}"
+      fill="none" stroke="var(--color-accent)" stroke-width="1.5" opacity="0.8"/>
+```
+
+### signal-wave
+Zigzag signal waveform:
+```xml
+<path d="M {ix} {iy} L {ix+4} {iy-6} L {ix+8} {iy+6} L {ix+12} {iy-6} L {ix+16} {iy}"
+      fill="none" stroke="var(--color-accent)" stroke-width="1.2" opacity="0.6"
+      stroke-linecap="round"/>
+```
+
+### shield
+Security shield outline:
+```xml
+<path d="M {ix-3} {iy-4} L {ix+4} {iy-8} L {ix+11} {iy-4} L {ix+11} {iy+6}
+         Q {ix+4} {iy+12}, {ix-3} {iy+6} Z"
+      fill="none" stroke="var(--color-accent)" stroke-width="1.2" opacity="0.6"/>
+```
+
+### heartbeat
+Animated pulsing circle (for monitoring/interoception):
+```xml
+<circle cx="{ix+4}" cy="{iy}" r="9" fill="none"
+        stroke="var(--color-accent)" stroke-width="1" opacity="0.5">
+  <animate attributeName="r" values="9;10;9" dur="2s" repeatCount="indefinite"/>
+  <animate attributeName="opacity" values="0.5;0.3;0.5" dur="2s" repeatCount="indefinite"/>
+</circle>
+<circle cx="{ix+4}" cy="{iy}" r="3" fill="var(--color-accent)" opacity="0.4">
+  <animate attributeName="opacity" values="0.4;0.7;0.4" dur="2s" repeatCount="indefinite"/>
+</circle>
+```
+
+### database
+Simple cylinder:
+```xml
+<ellipse cx="{ix+4}" cy="{iy-5}" rx="7" ry="3" fill="none"
+         stroke="var(--color-accent)" stroke-width="1" opacity="0.6"/>
+<line x1="{ix-3}" y1="{iy-5}" x2="{ix-3}" y2="{iy+5}"
+      stroke="var(--color-accent)" stroke-width="1" opacity="0.6"/>
+<line x1="{ix+11}" y1="{iy-5}" x2="{ix+11}" y2="{iy+5}"
+      stroke="var(--color-accent)" stroke-width="1" opacity="0.6"/>
+<ellipse cx="{ix+4}" cy="{iy+5}" rx="7" ry="3" fill="none"
+         stroke="var(--color-accent)" stroke-width="1" opacity="0.6"/>
+```
+
+### gear
+Simple cog outline:
+```xml
+<circle cx="{ix+4}" cy="{iy}" r="5" fill="none"
+        stroke="var(--color-accent)" stroke-width="1" opacity="0.6"/>
+<circle cx="{ix+4}" cy="{iy}" r="2" fill="var(--color-accent)" opacity="0.4"/>
+```
+
+---
+
+## Theme Variables (Defaults)
+
+If the host page doesn't define these, provide fallback values:
+
+```css
+:root {
+  --color-accent: #6366f1;
+  --color-accent-dim: #4f46e5;
+  --color-bg: #1a1a2e;
+  --color-bg-elevated: #16213e;
+  --color-border: #334155;
+  --color-border-subtle: #1e293b;
+  --color-text: #e2e8f0;
+  --color-text-muted: #94a3b8;
+  --color-text-faint: #64748b;
+  --font-mono: 'JetBrains Mono', 'Fira Code', monospace;
+  --font-sans: 'Inter', system-ui, sans-serif;
+}
+```
+
+These are dark-mode defaults. The point of CSS variables is that light-mode themes override them automatically — the SVG adapts without changes.
+
+---
+
+## Quality Checklist
+
+### SVG Validity
+- [ ] Valid inline SVG (no `xmlns` needed for inline, but include if standalone)
+- [ ] All `id` attributes are unique within the page
+- [ ] `viewBox` is set, no fixed `width`/`height` (responsive)
+- [ ] `aria-label` describes the diagram purpose
+
+### Theme Integration
+- [ ] ALL colors use `var(--color-*)` — zero hardcoded hex values
+- [ ] ALL fonts use `var(--font-*)` — no hardcoded font stacks
+- [ ] Works in both light and dark mode without changes
+
+### Animation
+- [ ] Flow lines animate with `stroke-dasharray` + `stroke-dashoffset`
+- [ ] Feedback loops animate in reverse direction (positive offset)
+- [ ] Highlighted layer has pulse ring (`opacity` animation)
+- [ ] No JavaScript required — pure CSS/SMIL animations
+- [ ] Animations are subtle (low opacity, slow duration)
+
+### Accessibility
+- [ ] SVG has `aria-label`
+- [ ] Layer groups have `data-layer` attributes
+- [ ] Animations respect `prefers-reduced-motion` (add media query)
+- [ ] Text is readable at small sizes (minimum 8px, prefer 9px+)
+
+### Responsiveness
+- [ ] No fixed pixel widths on the SVG element
+- [ ] `viewBox` maintains aspect ratio
+- [ ] Container has responsive padding (`p-4 sm:p-8`)
+- [ ] Readable on mobile (320px viewport)
+
+---
+
+## Reference Implementation
+
+See `portfolio/src/pages/lab.astro` — Five-layer agent architecture diagram with:
+- 5 vertically stacked layers with mini-icons
+- Downward flow lines with animated dashes between all layers
+- Feedback loop (Interoception → Learning) with reverse animation on the left
+- External signals input (left → Nervous System)
+- Measurement output (Learning → right)
+- Glow filter + pulse ring on the core (Learning) layer
+- Clickable layers linking to project doc sites
+- Full hover interaction CSS

--- a/skills/custom/llms-txt-generator/SKILL.md
+++ b/skills/custom/llms-txt-generator/SKILL.md
@@ -1,0 +1,448 @@
+---
+name: llms-txt-generator
+description: Generate llms.txt and llms-full.txt files for any MkDocs documentation site, following the llms.txt standard. Creates a curated index of doc pages and a MkDocs build hook that auto-generates the full inlined version from source markdown. Use when adding AI-queryable docs to a project with an existing MkDocs site.
+license: Complete terms in LICENSE.txt
+---
+
+# llms.txt Generator
+
+> Add AI-queryable documentation to any MkDocs site. Generates `llms.txt` (curated index) and a build hook that produces `llms-full.txt` (all docs inlined) from source markdown.
+
+## TL;DR Execution Flow
+
+```
+Phase 0: Pre-flight checks (MkDocs site exists, nav structure, GitHub Pages)
+Phase 1: Discovery (read mkdocs.yml nav, read all doc pages, classify sections)
+Phase 2: Generate llms.txt (curated index with section organization)
+Phase 3: Generate build hook (MkDocs on_pre_build hook for llms-full.txt)
+Phase 4: Wire into build (mkdocs.yml hooks, .gitignore, verify build)
+Phase 5: Commit, PR, verify deployment
+```
+
+## When to Use
+
+- Adding llms.txt to an existing MkDocs documentation site
+- Making project docs queryable by AI tools (Context7, mcpdoc, Claude Code, Cursor)
+- Phase 0 of a docs-as-MCP initiative
+
+## Inputs
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `project_root` | path | cwd | Project root directory |
+| `site_url` | string | from mkdocs.yml | Base URL for the docs site |
+| `optional_sections` | string[] | `["Theory", "Optional"]` | Nav sections to put under `## Optional` in llms.txt |
+| `issue_number` | int \| null | null | GitHub issue to close with the PR |
+
+---
+
+## Phase 0: Pre-Flight Checks
+
+### 0.1 MkDocs Site Exists
+
+```
+Verify:
+- mkdocs.yml exists at project root
+- docs/ directory exists with .md files
+- site_url is configured in mkdocs.yml (or provided as input)
+- nav: section exists in mkdocs.yml (required for structured generation)
+
+If mkdocs.yml has no nav:, STOP and inform user.
+The nav structure is what determines llms.txt organization.
+```
+
+### 0.2 Existing llms.txt
+
+```
+Check for:
+- docs/llms.txt        → Already exists, ask user: overwrite or update?
+- docs/llms-full.txt   → Generated file, safe to overwrite
+- hooks/ directory      → May already have MkDocs hooks
+- mkdocs.yml hooks:     → May already have hooks registered
+
+If llms.txt exists, switch to "update" mode.
+```
+
+### 0.3 GitHub Pages Status
+
+```bash
+# Is the site deployed?
+gh api "/repos/{OWNER}/{REPO}/pages" 2>/dev/null
+# 200 = deployed (we can verify URLs after)
+# 404 = not deployed (note for user)
+```
+
+---
+
+## Phase 1: Discovery
+
+**Goal:** Understand the docs structure completely before generating anything.
+
+### 1.1 Parse mkdocs.yml Nav
+
+Read `mkdocs.yml` and extract the full navigation tree:
+
+```
+For each nav entry:
+  - Section name (H2 in llms.txt)
+  - Page title
+  - Page path (relative to docs/)
+  - Nesting depth
+
+Output: Ordered list of (section, title, path) tuples
+```
+
+### 1.2 Read All Doc Pages
+
+For each page in the nav:
+
+```
+Read the .md file and extract:
+  - First heading (H1) — use as display name if different from nav title
+  - First paragraph — use as description in llms.txt link entry
+  - Total line count — for size estimation of llms-full.txt
+```
+
+### 1.3 Classify Sections
+
+Determine which nav sections are "core" vs "optional":
+
+```
+Core (always included):
+  - Getting Started, Installation, Quick Start
+  - Guides, How-to, Usage
+  - Reference, API, CLI
+  - Architecture
+
+Optional (included under ## Optional):
+  - Theory, Tutorials, Background
+  - Philosophy, About
+  - Roadmap, Changelog
+  - Contributing, Development
+  - Any section matching optional_sections input
+
+The user's optional_sections input overrides defaults.
+```
+
+---
+
+## Phase 2: Generate llms.txt
+
+### 2.1 Structure
+
+Follow the [llms.txt specification](https://llmstxt.org/):
+
+```markdown
+# {Project Name}
+
+> {site_description from mkdocs.yml}
+
+{Summary paragraph — 2-3 sentences describing what the project does,
+ its core mechanism, and primary use case. Derive from docs/index.md.}
+
+## {Core Section 1}
+
+- [{Page Title}]({full_url}): {One-line description from first paragraph}
+- [{Page Title}]({full_url}): {One-line description}
+
+## {Core Section 2}
+
+- [{Page Title}]({full_url}): {One-line description}
+
+## Optional
+
+- [{Page Title}]({full_url}): {One-line description}
+```
+
+### 2.2 URL Construction
+
+```
+base_url = site_url from mkdocs.yml (ensure trailing slash)
+
+For each page path from nav:
+  - getting-started/installation.md → {base_url}getting-started/installation/
+  - index.md → {base_url}
+  - theory/index.md → {base_url}theory/
+
+MkDocs URL convention: .md extension → trailing slash directory URL
+```
+
+### 2.3 Description Extraction
+
+For each page, generate a one-line description:
+
+```
+Priority:
+1. If page has a clear opening sentence, use it (truncate to ~100 chars)
+2. If page starts with a list of features, summarize: "Covers X, Y, and Z"
+3. If page is mostly code examples, describe: "Commands for X and Y"
+4. Fallback: Use the nav title as-is
+```
+
+### 2.4 Write File
+
+Write to `docs/llms.txt`. This file is committed to the repo.
+
+---
+
+## Phase 3: Generate Build Hook
+
+### 3.1 Hook Script
+
+Create `hooks/generate_llms_full.py`:
+
+```python
+"""MkDocs hook: generate llms-full.txt from llms.txt + source markdown.
+
+Runs on_pre_build so the generated file is available for MkDocs to copy
+to the site output directory.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from urllib.parse import urlparse
+
+SITE_URL = "{site_url}"  # From mkdocs.yml
+DOCS_DIR = Path(__file__).resolve().parent.parent / "docs"
+LLMS_TXT = DOCS_DIR / "llms.txt"
+LLMS_FULL_TXT = DOCS_DIR / "llms-full.txt"
+
+
+def _url_to_local_path(url: str) -> Path | None:
+    """Convert a site URL to a local docs/ markdown file path."""
+    parsed = urlparse(url)
+    path = parsed.path
+
+    # Strip the site prefix — extract from SITE_URL
+    prefix = urlparse(SITE_URL).path
+    if not path.startswith(prefix):
+        return None
+    relative = path[len(prefix):]
+
+    # Trailing slash -> try as directory/index.md first, then as file.md
+    if relative.endswith("/"):
+        relative += "index.md"
+    elif not relative.endswith(".md"):
+        relative += ".md"
+
+    candidate = DOCS_DIR / relative
+    if candidate.exists():
+        return candidate
+
+    # Try without the trailing directory (installation/ -> installation.md)
+    if relative.endswith("/index.md"):
+        alt = DOCS_DIR / relative.replace("/index.md", ".md")
+        if alt.exists():
+            return alt
+
+    return None
+
+
+def _parse_llms_txt(content: str) -> tuple[list[str], list[tuple[str, str, str]]]:
+    """Parse llms.txt into preamble lines and (section, name, url) entries."""
+    preamble: list[str] = []
+    entries: list[tuple[str, str, str]] = []
+    current_section = ""
+    in_preamble = True
+
+    for line in content.splitlines():
+        h2_match = re.match(r"^## (.+)$", line)
+        if h2_match:
+            current_section = h2_match.group(1)
+            in_preamble = False
+            continue
+
+        link_match = re.match(r"^- \[(.+?)\]\((.+?)\)", line)
+        if link_match:
+            name = link_match.group(1)
+            url = link_match.group(2)
+            entries.append((current_section, name, url))
+            in_preamble = False
+            continue
+
+        if in_preamble:
+            preamble.append(line)
+
+    return preamble, entries
+
+
+def generate_llms_full() -> str:
+    """Generate llms-full.txt content from llms.txt + source markdown."""
+    llms_content = LLMS_TXT.read_text()
+    preamble, entries = _parse_llms_txt(llms_content)
+
+    parts: list[str] = []
+    parts.append("\n".join(preamble).strip())
+    parts.append("")
+
+    current_section = ""
+    for section, name, url in entries:
+        if section != current_section:
+            current_section = section
+            parts.append(f"\n## {section}\n")
+
+        local_path = _url_to_local_path(url)
+        if local_path and local_path.exists():
+            md_content = local_path.read_text().strip()
+            parts.append(md_content)
+            parts.append("")
+        else:
+            parts.append(f"### {name}\n\nSee: {url}\n")
+
+    return "\n".join(parts)
+
+
+def on_pre_build(**kwargs) -> None:
+    """Generate llms-full.txt before MkDocs builds the site."""
+    if not LLMS_TXT.exists():
+        return
+    content = generate_llms_full()
+    LLMS_FULL_TXT.write_text(content)
+
+
+if __name__ == "__main__":
+    if not LLMS_TXT.exists():
+        print(f"Error: {LLMS_TXT} not found")
+        raise SystemExit(1)
+    content = generate_llms_full()
+    LLMS_FULL_TXT.write_text(content)
+    print(f"Generated {LLMS_FULL_TXT} ({len(content)} bytes)")
+```
+
+**IMPORTANT:** Replace `{site_url}` with the actual `site_url` from mkdocs.yml. The URL prefix extraction must match exactly.
+
+### 3.2 Hook Must Handle
+
+- Pages that resolve to `dir/index.md` or `dir.md` (MkDocs supports both)
+- Missing pages (fallback to link reference, don't crash)
+- Preamble preservation (H1, blockquote, overview paragraphs pass through)
+- Section headers from llms.txt H2s
+
+---
+
+## Phase 4: Wire Into Build
+
+### 4.1 Register Hook in mkdocs.yml
+
+Add to mkdocs.yml (before `markdown_extensions:` if it exists):
+
+```yaml
+hooks:
+  - hooks/generate_llms_full.py
+```
+
+If `hooks:` already exists, append to the list.
+
+### 4.2 Update .gitignore
+
+Add to .gitignore:
+
+```
+# Generated docs (rebuilt by MkDocs hook)
+docs/llms-full.txt
+```
+
+### 4.3 Verify Build
+
+```bash
+# Generate standalone
+python hooks/generate_llms_full.py
+
+# Full MkDocs build
+python -m mkdocs build --strict
+
+# Verify both files in site output
+ls -la site/llms.txt site/llms-full.txt
+```
+
+Both files must be present in `site/`. If `--strict` fails, fix warnings before proceeding.
+
+---
+
+## Phase 5: Commit, PR, Verify
+
+### 5.1 Branch and Commit
+
+```bash
+# Create branch (if not already on a feature branch)
+git checkout -b feat/llms-txt
+
+# Stage relevant files only
+git add docs/llms.txt hooks/generate_llms_full.py mkdocs.yml .gitignore
+
+# Commit
+git commit -m "feat: add llms.txt and build hook for AI-queryable docs"
+```
+
+Do NOT stage `docs/llms-full.txt` — it's generated and gitignored.
+
+### 5.2 Create PR
+
+```bash
+git push -u origin feat/llms-txt
+
+gh pr create \
+  --title "feat: add llms.txt for AI-queryable docs" \
+  --body "Adds llms.txt (curated index) and llms-full.txt (all docs inlined) \
+to the documentation site. MkDocs build hook auto-regenerates llms-full.txt \
+from source markdown on every build. Follows the llms.txt standard for \
+Context7, mcpdoc, and other AI tools. Closes #{issue_number}"
+```
+
+### 5.3 Post-Deploy Verification
+
+After merge and GitHub Pages deploy:
+
+```bash
+# Verify files are accessible
+curl -s -o /dev/null -w "%{http_code}" {site_url}llms.txt
+# Should return 200
+
+curl -s -o /dev/null -w "%{http_code}" {site_url}llms-full.txt
+# Should return 200
+
+# Test with mcpdoc (if available)
+# claude mcp add {project}-docs -- npx mcpdoc {site_url}llms.txt
+```
+
+---
+
+## Quality Checklist
+
+### llms.txt Content
+- [ ] H1 matches project name from mkdocs.yml
+- [ ] Blockquote has concise project summary
+- [ ] All nav pages are referenced (none missing)
+- [ ] URLs use full absolute paths with site_url prefix
+- [ ] Each link has a meaningful one-line description
+- [ ] Core sections come before ## Optional
+- [ ] Theory/background/changelog are under ## Optional
+
+### Build Hook
+- [ ] `SITE_URL` matches mkdocs.yml `site_url` exactly
+- [ ] All linked pages resolve to local .md files
+- [ ] Hook handles both `dir/index.md` and `dir.md` patterns
+- [ ] Missing pages fall back to link reference (no crash)
+- [ ] `python hooks/generate_llms_full.py` runs standalone
+- [ ] `mkdocs build --strict` passes
+
+### Integration
+- [ ] `hooks:` registered in mkdocs.yml
+- [ ] `docs/llms-full.txt` in .gitignore
+- [ ] Both files present in `site/` after build
+- [ ] Accessible at `{site_url}llms.txt` after deploy
+
+---
+
+## Reference: The llms.txt Standard
+
+From [llmstxt.org](https://llmstxt.org/):
+
+- Format: Markdown
+- Location: Site root (`/llms.txt`)
+- Required: H1 heading (project name)
+- Optional: Blockquote (summary), detail paragraphs, H2 sections with link lists
+- Special: `## Optional` section — content that can be skipped for shorter context
+- Companion: `llms-full.txt` — expanded version with all linked content inlined


### PR DESCRIPTION
## Summary

Two new custom skills:

- **llms-txt-generator** — Add AI-queryable docs (llms.txt + llms-full.txt build hook) to any MkDocs site. Follows the [llms.txt standard](https://llmstxt.org/) for Context7, mcpdoc, Claude Code, Cursor.
- **inline-svg-architecture-diagrams** — Generate production-quality inline SVG architecture diagrams with theme-aware CSS variables, animated flow lines, glow/pulse effects, feedback loops, responsive layout. Zero external dependencies. Reference impl: portfolio lab page.

## Test plan

- [x] llms-txt-generator proven on [buildlog-template PR #141](https://github.com/Peleke/buildlog-template/pull/141) (merged)
- [x] inline-svg-architecture-diagrams extracted from production portfolio site

🤖 Generated with [Claude Code](https://claude.com/claude-code)