### PR TITLE
Fix YAML frontmatter parse errors in pitch and _conventions

### DIFF
--- a/skills/custom/_conventions.md
+++ b/skills/custom/_conventions.md
@@ -1,3 +1,8 @@
+---
+name: hunter-conventions
+description: "Shared conventions for the hunter product-discovery pipeline: canonical paths, frontmatter contracts, folder-to-type mapping, statuses, tags, cross-references, and the PipelineEnvelope schema."
+---
+
 # Hunter Pipeline Conventions
 ## Preamble — loaded by every skill in the hunter pipeline
 

--- a/skills/custom/pitch/SKILL.md
+++ b/skills/custom/pitch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pitch
-description: Go-to-market launch engine -- takes offer-scope build spec (positioning, distribution plan, revenue model, kill criteria) plus persona data and SWOT analysis, then produces the complete launch kit: landing page copy, launch posts, GitHub product README, email sequence, launch checklist, A/B test spec, and refined kill criteria. Use when converting a validated offer spec into ready-to-execute go-to-market materials.
+description: "Go-to-market launch engine -- takes offer-scope build spec (positioning, distribution plan, revenue model, kill criteria) plus persona data and SWOT analysis, then produces the complete launch kit: landing page copy, launch posts, GitHub product README, email sequence, launch checklist, A/B test spec, and refined kill criteria. Use when converting a validated offer spec into ready-to-execute go-to-market materials."
 license: MIT
 ---
 


### PR DESCRIPTION
## Summary
- **pitch/SKILL.md**: Quoted the `description` value to prevent an unquoted colon (`launch kit: landing page`) from being misinterpreted as a YAML mapping separator
- **_conventions.md**: Added missing YAML frontmatter block with `name` and `description` fields

Both files now pass `quick_validate.py` cleanly.

## Test plan
- [x] `quick_validate.py` passes for `pitch`
- [x] `_conventions.md` frontmatter parses without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)