### PR TITLE
Add OpenClaw metadata to all custom skills

### DIFF
--- a/skills/custom/chapter-generator/SKILL.md
+++ b/skills/custom/chapter-generator/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: chapter-generator
 description: Generate a single tutorial chapter from a structured spec. Triggers on "generate chapter", "create the [chapter] tutorial", "write chapter [N]", "/chapter-gen". Takes a chapter spec (from curriculum-planner or inline) and produces a Markdown file following the configured voice guide, with MkDocs-compatible formatting.
+metadata:
+  openclaw:
+    emoji: "\u270D\uFE0F"
 ---
 
 # Chapter Generator

--- a/skills/custom/community-pitch/SKILL.md
+++ b/skills/custom/community-pitch/SKILL.md
@@ -2,6 +2,9 @@
 name: community-pitch
 description: Community pitch engine -- takes persona extraction output and signal scan data, then produces a complete paid community plan with concept, platform recommendation, membership tiers, content cadence, launch plan, economics, community structure, and bundling strategy. Use when converting validated persona insights into a recurring-revenue community business (primarily Skool, but platform-agnostic).
 license: MIT
+metadata:
+  openclaw:
+    emoji: "\U0001F3D8\uFE0F"
 ---
 
 # Community Pitch

--- a/skills/custom/content-planner/SKILL.md
+++ b/skills/custom/content-planner/SKILL.md
@@ -8,6 +8,11 @@ description: >
   writing ideas from recent engineering work, or populate their Obsidian vault with
   content tasks. Invoked via /content-planner or when user asks about content
   scheduling, writing plans, or "what should I write about."
+metadata:
+  openclaw:
+    emoji: "\U0001F4F0"
+    requires:
+      bins: ["gh", "python3"]
 ---
 
 # Content Planner

--- a/skills/custom/curriculum-planner/SKILL.md
+++ b/skills/custom/curriculum-planner/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: curriculum-planner
 description: Interactive elicitation protocol for designing tutorial series. Triggers on "plan a tutorial", "design a curriculum", "I want to teach [topic]", "/curriculum-plan". Runs structured elicitation across 5 dimensions, produces YAML outline + per-chapter specs ready for the chapter-generator skill.
+metadata:
+  openclaw:
+    emoji: "\U0001F5FA\uFE0F"
 ---
 
 # Curriculum Planner

--- a/skills/custom/decision-log/SKILL.md
+++ b/skills/custom/decision-log/SKILL.md
@@ -2,6 +2,9 @@
 name: decision-log
 description: Structured product decision engine -- takes signal scan output and operator preferences, applies the Signal-to-Decision Pipeline (SDP) framework, and produces a scored, filtered, bias-checked decision record with pre-mortem analysis and kill criteria. Use when choosing which opportunity to pursue from a completed signal scan.
 license: MIT
+metadata:
+  openclaw:
+    emoji: "\u2696\uFE0F"
 ---
 
 # Decision Log

--- a/skills/custom/hunter-log/SKILL.md
+++ b/skills/custom/hunter-log/SKILL.md
@@ -2,6 +2,9 @@
 name: hunter-log
 description: Persistence layer for the hunter product discovery pipeline. Takes PipelineEnvelope JSON from any pipeline skill (signal-scan, decision-log, persona-extract, offer-scope) and saves it as structured, Obsidian-compatible markdown with proper frontmatter, tags, cross-links, session tracking, and kanban board updates.
 license: MIT
+metadata:
+  openclaw:
+    emoji: "\U0001F4D2"
 ---
 
 # Hunter Log

--- a/skills/custom/inline-svg-architecture-diagrams/SKILL.md
+++ b/skills/custom/inline-svg-architecture-diagrams/SKILL.md
@@ -2,6 +2,9 @@
 name: inline-svg-architecture-diagrams
 description: Generate production-quality inline SVG architecture diagrams with theme-aware CSS variables, animated flow lines, glow effects, feedback loops, and responsive layout. No external dependencies, no build steps, no image files. Use when creating system architecture visuals that integrate with a design system.
 license: Complete terms in LICENSE.txt
+metadata:
+  openclaw:
+    emoji: "\U0001F3D7\uFE0F"
 ---
 
 # Inline SVG Architecture Diagrams

--- a/skills/custom/issue/SKILL.md
+++ b/skills/custom/issue/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: issue
 description: Draft well-structured GitHub issues with clear titles, structured descriptions, acceptance criteria, and appropriate labels. Use this skill when a user asks to create, write, or draft a GitHub issue, bug report, feature request, task ticket, or RFC/proposal. Also use when a user asks to file an issue, open a ticket, or report a bug.
+metadata:
+  openclaw:
+    emoji: "\U0001F3AB"
+    requires:
+      bins: ["gh"]
 ---
 
 # GitHub Issue Drafting

--- a/skills/custom/llms-txt-generator/SKILL.md
+++ b/skills/custom/llms-txt-generator/SKILL.md
@@ -2,6 +2,11 @@
 name: llms-txt-generator
 description: Generate llms.txt and llms-full.txt files for any MkDocs documentation site, following the llms.txt standard. Creates a curated index of doc pages and a MkDocs build hook that auto-generates the full inlined version from source markdown. Use when adding AI-queryable docs to a project with an existing MkDocs site.
 license: Complete terms in LICENSE.txt
+metadata:
+  openclaw:
+    emoji: "\U0001F916"
+    requires:
+      bins: ["python3"]
 ---
 
 # llms.txt Generator

--- a/skills/custom/mkdocs-site-generator/SKILL.md
+++ b/skills/custom/mkdocs-site-generator/SKILL.md
@@ -2,6 +2,11 @@
 name: mkdocs-site-generator
 description: Generate a complete MkDocs documentation site with GitHub Pages CI/CD for any TypeScript/Node.js codebase. Covers discovery, architecture, scaffold, content generation, CI/CD setup, and cross-reference verification. Use when setting up docs for a new or existing project.
 license: Complete terms in LICENSE.txt
+metadata:
+  openclaw:
+    emoji: "\U0001F4DA"
+    requires:
+      bins: ["python3", "pip", "gh"]
 ---
 
 # MkDocs Site Generator

--- a/skills/custom/offer-scope/SKILL.md
+++ b/skills/custom/offer-scope/SKILL.md
@@ -2,6 +2,9 @@
 name: offer-scope
 description: Offer scoping engine -- takes persona extraction output (pain stories, decision points, buying triggers, archetypes) and signal scan SPEND data, then produces a complete 1-day build spec with positioning, distribution plan, and revenue model. Use when converting validated persona insights into a shippable product spec.
 license: MIT
+metadata:
+  openclaw:
+    emoji: "\U0001F3AF"
 ---
 
 # Offer Scope

--- a/skills/custom/persona-extract/SKILL.md
+++ b/skills/custom/persona-extract/SKILL.md
@@ -2,6 +2,9 @@
 name: persona-extract
 description: Persona extraction engine -- takes decision-log output and signal scan data, then produces deep persona research with real stories, decision points, Four Forces analysis, and offer mapping. Uses web search to find real evidence. Use when converting validated market signals into evidence-based buyer personas grounded in real stories.
 license: MIT
+metadata:
+  openclaw:
+    emoji: "\U0001F464"
 ---
 
 # Persona Extract

--- a/skills/custom/pitch/SKILL.md
+++ b/skills/custom/pitch/SKILL.md
@@ -2,6 +2,9 @@
 name: pitch
 description: "Go-to-market launch engine -- takes offer-scope build spec (positioning, distribution plan, revenue model, kill criteria) plus persona data and SWOT analysis, then produces the complete launch kit: landing page copy, launch posts, GitHub product README, email sequence, launch checklist, A/B test spec, and refined kill criteria. Use when converting a validated offer spec into ready-to-execute go-to-market materials."
 license: MIT
+metadata:
+  openclaw:
+    emoji: "\U0001F680"
 ---
 
 # Pitch

--- a/skills/custom/signal-scan/SKILL.md
+++ b/skills/custom/signal-scan/SKILL.md
@@ -2,6 +2,9 @@
 name: signal-scan
 description: Product signal scanner -- identifies market opportunities by analyzing pain points, demand, spend, sentiment, competitive landscape, and audience signals across Reddit, social media, course marketplaces, and other sources. Use when scanning a domain for product opportunities, running a market analysis, or identifying what to build and sell next.
 license: MIT
+metadata:
+  openclaw:
+    emoji: "\U0001F4E1"
 ---
 
 # Signal Scan

--- a/skills/custom/sketches/SKILL.md
+++ b/skills/custom/sketches/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: sketches
 description: Create hand-drawn-style visual sketches, wireframes, and diagrams using inline SVG. Produces rough, sketchy visuals with a whiteboard/napkin aesthetic (think Balsamiq or Excalidraw). Use when users ask to sketch, wireframe, mock up, diagram, or visually explain something -- including UI wireframes, architecture diagrams, flowcharts, process diagrams, concept sketches, and brainstorming visuals. Also use when users say "draw", "sketch", "wireframe", "mock up", "diagram", or "visualize".
+metadata:
+  openclaw:
+    emoji: "\u270F\uFE0F"
 ---
 
 # Sketches

--- a/skills/custom/skool-pitch/SKILL.md
+++ b/skills/custom/skool-pitch/SKILL.md
@@ -2,6 +2,9 @@
 name: skool-pitch
 description: Skool-specific community pitch engine -- takes a topic, operator edge, and target audience (with optional persona and signal scan data from the hunter pipeline) and produces a complete Skool community plan with concept, competitive landscape, gamification design, pricing, content architecture, launch playbook (including Skool Games and affiliate strategy), economics, value ladder, and risk assessment. General-purpose -- works for any topic from DevOps to watercolor painting.
 license: MIT
+metadata:
+  openclaw:
+    emoji: "\U0001F393"
 ---
 
 # Skool Pitch

--- a/skills/custom/swot-analysis/SKILL.md
+++ b/skills/custom/swot-analysis/SKILL.md
@@ -2,6 +2,9 @@
 name: swot-analysis
 description: Evidence-grounded SWOT analysis engine -- takes persona extraction output, signal scan data, format research, and market hypothesis, then produces a brutally honest Strengths/Weaknesses/Opportunities/Threats analysis with verdict (proceed/pivot/kill), risk registry, and moat assessment. Use when stress-testing a product hypothesis before committing to a build spec.
 license: MIT
+metadata:
+  openclaw:
+    emoji: "\U0001F50D"
 ---
 
 # SWOT Analysis


### PR DESCRIPTION
## Summary
- Added `metadata.openclaw` frontmatter to all 17 custom skills per the [OpenClaw spec](https://docs.openclaw.ai/tools/skills)
- Every skill gets an **emoji** for macOS Skills UI display
- 4 skills with external dependencies get **`requires.bins`** gating:
  - `content-planner` → `gh`, `python3`
  - `mkdocs-site-generator` → `python3`, `pip`, `gh`
  - `llms-txt-generator` → `python3`
  - `issue` → `gh`
- Remaining 13 skills are pure content generation with no binary requirements

| Emoji | Skill | Bins |
|-------|-------|------|
| ✍️ | chapter-generator | - |
| 🏘️ | community-pitch | - |
| 📰 | content-planner | gh, python3 |
| 🗺️ | curriculum-planner | - |
| ⚖️ | decision-log | - |
| 📒 | hunter-log | - |
| 🏗️ | inline-svg-architecture-diagrams | - |
| 🎫 | issue | gh |
| 🤖 | llms-txt-generator | python3 |
| 📚 | mkdocs-site-generator | python3, pip, gh |
| 🎯 | offer-scope | - |
| 👤 | persona-extract | - |
| 🚀 | pitch | - |
| 📡 | signal-scan | - |
| ✏️ | sketches | - |
| 🎓 | skool-pitch | - |
| 🔍 | swot-analysis | - |

## Test plan
- [x] All 17 skills pass `quick_validate.py`
- [x] YAML frontmatter parses correctly with emoji rendering
- [x] `requires.bins` arrays correctly structured for gated skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)