### PR TITLE
Add reddit-harvest skill

### DIFF
--- a/skills/custom/reddit-harvest/SKILL.md
+++ b/skills/custom/reddit-harvest/SKILL.md
@@ -1,0 +1,498 @@
+---
+name: reddit-harvest
+description: >
+  Playwright-driven Reddit quote harvester for the "From the Wild" content pipeline.
+  Uses a logged-in browser session to search subreddits, extract pain quotes with full
+  metadata, score them using wild-scan's rubric, and export in wild-scan format. Feeds
+  directly into wild-scan Phase 3+ (scoring, clustering, briefs).
+license: MIT
+metadata:
+  openclaw:
+    emoji: "\U0001F4E1"
+    requires:
+      mcp: ["playwright"]
+---
+
+# Reddit Harvest
+
+Drive a logged-in Reddit browser session via Playwright MCP to harvest pain quotes that web search can't reach. Output conforms to wild-scan format — drop it straight into the content pipeline.
+
+## Step 0: Load Conventions
+
+Before doing ANYTHING, read the shared conventions file:
+
+```
+Read /Users/peleke/Documents/Projects/skills/skills/custom/_conventions.md
+```
+
+This file defines: canonical vault path, folder-to-type mapping, frontmatter contract, valid statuses, tag hierarchy, cross-reference syntax, and the PipelineEnvelope schema. All output from this skill MUST conform to those conventions. If there is a conflict between this SKILL.md and `_conventions.md`, the conventions file wins.
+
+## When to Use
+
+- wild-scan's web search can't reliably access Reddit (`site:reddit.com` queries get blocked)
+- You need a targeted harvest from specific subreddits
+- You want deeper comment extraction than search snippets provide
+- Supplementing a wild-scan run with Reddit-specific quotes
+- Building a Reddit-only quote index for a topic
+
+## Trigger Phrases
+
+- "Harvest Reddit for [topic] pain"
+- "Reddit scan for [topic]"
+- "Scrape Reddit for [topic] quotes"
+- "Run reddit-harvest on [topic]"
+- "/reddit-harvest [topic]"
+- "Get me Reddit quotes about [topic]"
+
+---
+
+## Prerequisites
+
+Before starting, establish with the user:
+
+1. **Topic focus** — What specific area to harvest (e.g., "Kubernetes deployment pain", "Terraform state management")
+2. **Target subreddits** — Specific subreddits to search, or use defaults from [references/subreddit-targets.md](references/subreddit-targets.md)
+3. **Min engagement threshold** — Minimum upvotes to consider a post worth drilling into (default: 10)
+4. **Pain queries** — Specific search terms, or use defaults from wild-scan's [search-playbook.md](/Users/peleke/Documents/Projects/skills/skills/custom/wild-scan/references/search-playbook.md)
+5. **Posts per subreddit** — How many top posts to drill into per subreddit (default: 10)
+
+If the user says "just go" with a topic, use these defaults:
+- **Subreddits**: Top 3-5 from the topic's domain in subreddit-targets.md
+- **Engagement threshold**: 10 upvotes
+- **Pain queries**: Frustration + help-seeking + gap queries from search-playbook.md
+- **Posts per subreddit**: 10
+
+### Browser Session Requirement
+
+**The user MUST be logged into Reddit in the Playwright browser before this skill runs.** The skill does not handle login — it assumes an authenticated session.
+
+To verify, the skill checks login state at the start of Phase 1 (see below). If not logged in, stop and ask the user to log in.
+
+---
+
+## Workflow
+
+```
+User logs into Reddit in Playwright browser
+    |
+Skill receives: topic + subreddits + pain queries
+    |
+Phase 1: Search — Navigate to subreddit search URLs
+    |
+Phase 2: Scan — Snapshot pages, identify high-signal posts
+    |
+Phase 3: Harvest — Click into threads, extract quotes + metadata
+    |
+Phase 4: Score — Apply wild-scan 4-dimension rubric
+    |
+Phase 5: Export — Write vault Markdown + JSON in wild-scan format
+```
+
+---
+
+## Phase 1: Search
+
+### Load References
+
+Read these files before starting:
+
+```
+Read /Users/peleke/Documents/Projects/skills/skills/custom/reddit-harvest/references/selectors.md
+Read /Users/peleke/Documents/Projects/skills/skills/custom/reddit-harvest/references/subreddit-targets.md
+Read /Users/peleke/Documents/Projects/skills/skills/custom/wild-scan/references/scoring-rubric.md
+Read /Users/peleke/Documents/Projects/skills/skills/custom/wild-scan/references/search-playbook.md
+```
+
+### Verify Login
+
+Navigate to Reddit and check login state:
+
+1. `browser_navigate` to `https://www.reddit.com`
+2. `browser_evaluate` with the login-check snippet from selectors.md
+3. If not logged in → **STOP**. Tell the user: "Please log into Reddit in the browser window. I'll wait."
+4. If logged in → proceed
+
+### Build Search URLs
+
+For each subreddit + pain query combination, construct:
+
+```
+https://www.reddit.com/r/{subreddit}/search/?q={pain_query}&sort=top&t=year
+```
+
+Pain query categories (from search-playbook.md, adapted for direct Reddit search):
+
+**Frustration signals:**
+```
+"I hate" OR "I'm frustrated" OR "nightmare"
+"why is it so hard" OR "am I dumb" OR "what am I missing"
+"wasted hours" OR "wasted days" OR "spent all weekend"
+```
+
+**Help-seeking signals:**
+```
+"how do I actually" OR "serious question"
+"I finished the tutorial" OR "tutorial hell"
+"where do I start" OR "overwhelmed"
+```
+
+**Gap signals (tutorial-to-production):**
+```
+"nobody teaches" OR "no one explains"
+"real world" OR "production" OR "not hello world"
+```
+
+**Wish signals (latent demand):**
+```
+"I wish" OR "if only" OR "someone should make"
+```
+
+### Execute Searches
+
+For each search URL:
+
+1. `browser_navigate` to the URL
+2. Wait for results to load: `browser_wait_for` with a reasonable selector (e.g., any post link)
+3. `browser_evaluate` with the search results extraction script from selectors.md
+4. Collect all post data into a master list
+
+**Pace yourself.** Wait 1-2 seconds between navigations to avoid rate limiting. If Reddit shows a rate-limit page, pause for 30 seconds and retry.
+
+---
+
+## Phase 2: Scan
+
+### Filter and Rank
+
+From the master post list:
+
+1. **Deduplicate** — same post may appear in multiple query results (match by `postId`)
+2. **Filter** — remove posts below the engagement threshold
+3. **Rank** — sort by comment count descending (more comments = more quote potential)
+4. **Select** — take top N per subreddit (default: 10)
+
+### Present Scan Summary
+
+Show the user a summary before drilling into threads:
+
+```
+## Scan Summary
+
+Searched: r/devops, r/kubernetes, r/terraform
+Queries: 4 pain-query categories x 3 subreddits = 12 searches
+Posts found: 87 (after dedup)
+Posts above threshold (10+ upvotes): 43
+Selected for harvest: 30 (top 10 per subreddit)
+
+Top posts by engagement:
+1. "Why does nobody teach real CI/CD?" — r/devops, 342 upvotes, 89 comments
+2. "Terraform state is a nightmare" — r/terraform, 256 upvotes, 67 comments
+...
+```
+
+If the user wants to adjust (add/remove posts, change subreddits), do so before proceeding.
+
+---
+
+## Phase 3: Harvest
+
+For each selected post, extract quotes:
+
+### Thread Extraction Flow
+
+1. `browser_navigate` to the post URL
+2. `browser_run_code` with the scroll-and-load script from selectors.md (loads lazy comments)
+3. `browser_evaluate` with the post metadata extraction script
+4. `browser_evaluate` with the comment extraction script
+
+### Quote Selection
+
+Not every comment is a harvestable quote. From the extracted comments, select those that:
+
+- **Are pain statements** — frustration, struggle, help-seeking, wishing (not advice-giving, not jokes, not meta-discussion)
+- **Have substance** — minimum ~50 characters of meaningful content (not just "same" or "+1")
+- **Have engagement** — prioritize comments with upvotes (use the engagement threshold, but can be lower than the post threshold — even 5+ upvotes on a comment is signal)
+
+### For Each Harvestable Quote, Capture:
+
+| Field | Source |
+|-------|--------|
+| `quote` | Exact comment text from extraction |
+| `author` | `u/{author}` from extraction |
+| `platform` | `"reddit"` (hardcoded) |
+| `community` | `r/{subreddit}` from post metadata |
+| `url` | Comment permalink from extraction |
+| `date` | Comment timestamp from extraction |
+| `engagement.metric` | `"upvotes"` |
+| `engagement.value` | Comment upvote count |
+| `engagement.replies` | Reply count from extraction |
+| `engagement.same_here_count` | Run same-here detection script from selectors.md |
+| `context` | Post title + parent comment text (if the quote is a reply) |
+| `pain_category` | Run pain-category matcher from selectors.md, then verify manually |
+
+### Same-Here Detection
+
+For high-value comments (20+ upvotes), run the same-here detection script from selectors.md to count agreement replies. This feeds the engagement scoring dimension.
+
+### Progress Updates
+
+After every 5 threads, update the user:
+
+```
+Harvested 5/30 threads. 23 quotes so far. Continuing...
+```
+
+---
+
+## Phase 4: Score
+
+Apply wild-scan's 4-dimension scoring rubric to every harvested quote. See the full rubric at:
+
+```
+/Users/peleke/Documents/Projects/skills/skills/custom/wild-scan/references/scoring-rubric.md
+```
+
+### Scoring Summary
+
+| Dimension | Weight | What It Measures |
+|-----------|--------|------------------|
+| Specificity | 2x | Names tools, versions, exact scenarios vs. vague complaints |
+| Intensity | 2x | Emotional language, time/effort wasted, desperation level |
+| Solvability | 2x | Can we build a repo that demolishes this? |
+| Engagement | 1x | Social proof — upvotes calibrated by platform |
+
+### Reddit-Specific Engagement Calibration
+
+From the scoring rubric's platform table:
+
+| Type | Low (1-3) | Medium (4-6) | High (7-8) | Extreme (9-10) |
+|------|-----------|--------------|------------|----------------|
+| Reddit comment | 0-10 upvotes | 10-50 upvotes | 50-200 upvotes | 200+ upvotes |
+| Reddit post | 0-20 upvotes | 20-100 upvotes | 100-500 upvotes | 500+ upvotes |
+
+**Niche subreddit adjustment:** If harvesting from a small subreddit (<100K members), boost engagement score by +1 for the same upvote counts. 30 upvotes on r/terraform is worth more than 30 on r/programming.
+
+### Overall Score
+
+```
+overall = (specificity * 2 + intensity * 2 + solvability * 2 + engagement * 1) / 7
+```
+
+### Scoring Discipline
+
+Every score MUST have a one-sentence justification. Example:
+
+```
+specificity: 8 — "Calls out the exact gap: passing secrets from GitHub Actions to EKS."
+intensity: 7 — "Used 'losing my mind', described 3 days of debugging."
+solvability: 9 — "A secrets-management tutorial with working GHA + EKS config would directly solve this."
+engagement: 6 — "47 upvotes, 12 replies including 3 'same here' responses."
+overall: 7.7
+```
+
+---
+
+## Phase 5: Export
+
+Produce two output files matching wild-scan's format exactly.
+
+**Vault path:** `/Users/peleke/Library/Mobile Documents/iCloud~md~obsidian/Documents/ClawTheCurious/`
+
+### 1. Markdown Quote Index
+
+**Path:** `{vault}/Writing/From-The-Wild/{topic-slug}-reddit-{YYYY-MM-DD}.md`
+
+```markdown
+---
+type: wild-index
+date: YYYY-MM-DD
+status: active
+topic: "[topic focus]"
+source: reddit-harvest
+platforms_searched:
+  - reddit
+subreddits: [list of subreddits searched]
+quote_count: N
+tags:
+  - content/from-the-wild
+  - hunter/domain/{domain-slug}
+---
+
+# Reddit Harvest: [Topic]
+
+**Date**: YYYY-MM-DD
+**Source**: reddit-harvest (Playwright MCP)
+**Subreddits**: r/sub1, r/sub2, r/sub3
+**Quotes harvested**: N
+**Engagement threshold**: X upvotes
+
+## Summary Stats
+
+| Metric | Value |
+|--------|-------|
+| Subreddits searched | N |
+| Posts scanned | N |
+| Quotes harvested | N |
+| Avg overall score | X.X |
+| Quotes scoring 7+ | N |
+| Top pain category | [category] |
+
+## Top Quotes (Score 7+)
+
+### 1. (Score: X.X)
+> "[Full quote text]"
+> — u/[author], r/[subreddit], [upvotes] upvotes
+
+- **Pain category**: [category]
+- **URL**: [permalink]
+- **Context**: [post title / parent comment]
+- **Scoring**: specificity X, intensity X, solvability X, engagement X
+
+### 2. (Score: X.X)
+[repeat for all quotes scoring 7+]
+
+## All Quotes by Subreddit
+
+### r/[subreddit1]
+
+| Score | Quote (truncated) | Author | Upvotes | Category |
+|-------|-------------------|--------|---------|----------|
+| X.X | "[first 80 chars]..." | u/name | N | [cat] |
+
+### r/[subreddit2]
+[repeat]
+
+## Full Quote Log
+
+### Quote 1 (Score: X.X)
+> "[Full quote text]"
+
+- **Author**: u/[username]
+- **Platform**: reddit
+- **Community**: r/[subreddit]
+- **URL**: [permalink]
+- **Date**: [timestamp]
+- **Engagement**: [upvotes] upvotes, [replies] replies, [same_here] "same here"
+- **Context**: [post title]
+- **Pain category**: [category]
+- **Scoring**:
+  - specificity: X — "[justification]"
+  - intensity: X — "[justification]"
+  - solvability: X — "[justification]"
+  - engagement: X — "[justification]"
+
+### Quote 2 (Score: X.X)
+[repeat for all quotes]
+```
+
+### 2. JSON Index
+
+**Path:** `{vault}/Writing/From-The-Wild/wild-scan-{topic-slug}-reddit-{YYYY-MM-DD}.json`
+
+Conforms to wild-scan's `output-schema.json`. The JSON structure:
+
+```json
+{
+  "scan_metadata": {
+    "topic": "[topic]",
+    "date": "YYYY-MM-DD",
+    "learning_stage": "[stage from user or inferred]",
+    "repo_angle": "[angle from user or inferred]",
+    "platforms_searched": ["reddit"],
+    "total_quotes": N
+  },
+  "quotes": [
+    {
+      "quote": "[exact text]",
+      "author": "u/[username]",
+      "platform": "reddit",
+      "community": "r/[subreddit]",
+      "url": "[permalink]",
+      "date": "[timestamp]",
+      "engagement": {
+        "metric": "upvotes",
+        "value": N,
+        "replies": N,
+        "same_here_count": N
+      },
+      "context": "[post title + parent if reply]",
+      "pain_category": "[category]",
+      "scores": {
+        "specificity": { "value": N, "justification": "..." },
+        "intensity": { "value": N, "justification": "..." },
+        "solvability": { "value": N, "justification": "..." },
+        "engagement": { "value": N, "justification": "..." }
+      },
+      "overall_score": N,
+      "theme_id": "[assigned during wild-scan Phase 4]"
+    }
+  ],
+  "themes": [],
+  "content_briefs": []
+}
+```
+
+**Note on `themes` and `content_briefs`:** reddit-harvest exports these as empty arrays. Theme clustering and brief generation happen in wild-scan Phases 4-6. The JSON is valid against the schema with empty arrays — the `minItems: 15` constraint applies to `quotes`, not themes or briefs.
+
+If the operator wants to run a complete pipeline (harvest + cluster + brief) in one session, they can invoke wild-scan after reddit-harvest finishes, pointing it at the exported JSON.
+
+### Pipeline Integration
+
+After export, the output is ready for:
+
+1. **wild-scan Phase 4** — Feed the JSON into theme clustering. wild-scan reads quotes from the JSON and clusters them.
+2. **content-planner** — The Markdown file lands in `Writing/From-The-Wild/` where content-planner picks it up on its next scan.
+3. **Manual review** — The Markdown file is readable in Obsidian for direct browsing and editing.
+
+---
+
+## Rate Limiting & Etiquette
+
+- **Navigation pace**: Wait 1-2 seconds between page loads
+- **Comment loading**: The scroll script has built-in 750ms pauses
+- **If rate-limited**: Reddit shows an interstitial. Pause 30-60 seconds, then retry the same URL
+- **Session length**: A typical harvest (3 subreddits, 10 posts each) takes 15-25 minutes of browser time
+- **Don't overdo it**: One harvest session per topic per day is plenty. Reddit may flag accounts with excessive automated browsing.
+
+---
+
+## Quality Checklist
+
+Run this before delivering results:
+
+- [ ] Browser session verified as logged in before starting
+- [ ] All target subreddits searched with pain queries
+- [ ] Posts filtered by engagement threshold and ranked by comment count
+- [ ] Minimum 15 quotes harvested (aim for 20-30)
+- [ ] Every quote has: exact text, author, r/subreddit, permalink, upvotes, timestamp, context
+- [ ] Same-here detection run on high-value comments (20+ upvotes)
+- [ ] Pain category auto-suggested and verified for each quote
+- [ ] Every quote scored on 4 dimensions with one-sentence justifications
+- [ ] Engagement scores use Reddit-specific calibration from scoring rubric
+- [ ] Niche subreddit adjustment applied where appropriate
+- [ ] Markdown file has correct frontmatter (type: wild-index, source: reddit-harvest)
+- [ ] JSON file conforms to wild-scan output-schema.json
+- [ ] Both files written to `{vault}/Writing/From-The-Wild/`
+- [ ] No duplicate quotes from previous wild-scan or reddit-harvest runs (check existing indices)
+- [ ] User shown summary stats before and after harvest
+
+---
+
+## Resources
+
+### Internal References
+- `references/selectors.md` — Reddit DOM selectors and extraction JavaScript
+- `references/subreddit-targets.md` — Priority subreddits by domain
+
+### Wild-Scan References (consumed, not duplicated)
+- `/Users/peleke/Documents/Projects/skills/skills/custom/wild-scan/references/scoring-rubric.md` — 4-dimension scoring calibration
+- `/Users/peleke/Documents/Projects/skills/skills/custom/wild-scan/references/search-playbook.md` — Pain query templates
+- `/Users/peleke/Documents/Projects/skills/skills/custom/wild-scan/references/output-schema.json` — JSON output schema
+
+### Playwright MCP Tools Used
+- `browser_navigate` — Load Reddit URLs
+- `browser_wait_for` — Wait for page elements
+- `browser_snapshot` — Accessibility tree for debugging
+- `browser_evaluate` — Run extraction JavaScript (returns data)
+- `browser_run_code` — Run scroll/interaction scripts (side effects)
+- `browser_click` — Click into threads, load more comments

--- a/skills/custom/reddit-harvest/references/selectors.md
+++ b/skills/custom/reddit-harvest/references/selectors.md
@@ -1,0 +1,465 @@
+# Reddit DOM Selectors & Extraction Scripts
+
+JavaScript snippets for extracting data from Reddit pages via Playwright MCP's `browser_evaluate` and `browser_run_code`. Reddit's DOM changes frequently — update these when extraction breaks.
+
+> **Last verified**: 2026-02-12 (new Reddit / sh.reddit.com layout)
+
+---
+
+## Search Results Page
+
+Navigate to: `https://www.reddit.com/r/{subreddit}/search/?q={query}&sort=top&t=year`
+
+### Extract Search Results
+
+Pass to `browser_evaluate`:
+
+```javascript
+// Extract post cards from search results
+(() => {
+  const posts = [];
+  // Target the search result post containers
+  const postElements = document.querySelectorAll('search-telemetry-tracker, [data-testid="search-result-link"], faceplate-tracker[source="search"]');
+
+  // Fallback: grab all article-like containers with links to reddit posts
+  const candidates = postElements.length > 0
+    ? postElements
+    : document.querySelectorAll('a[href*="/comments/"]');
+
+  const seen = new Set();
+
+  candidates.forEach(el => {
+    try {
+      // Find the nearest post container
+      const container = el.closest('[data-testid="search-result-link"]')
+        || el.closest('faceplate-tracker')
+        || el.closest('div[data-fullname]')
+        || el;
+
+      // Extract permalink
+      const linkEl = container.querySelector('a[href*="/comments/"]') || container;
+      const href = linkEl?.getAttribute('href') || linkEl?.href || '';
+      const url = href.startsWith('http') ? href : `https://www.reddit.com${href}`;
+
+      // Deduplicate
+      const postId = href.match(/comments\/([a-z0-9]+)/)?.[1];
+      if (!postId || seen.has(postId)) return;
+      seen.add(postId);
+
+      // Title — look for heading elements or link text
+      const titleEl = container.querySelector('a[id*="post-title"]')
+        || container.querySelector('[slot="title"]')
+        || container.querySelector('h2, h3')
+        || linkEl;
+      const title = titleEl?.textContent?.trim() || '';
+
+      // Author
+      const authorEl = container.querySelector('a[href*="/user/"]');
+      const author = authorEl?.textContent?.trim()?.replace(/^u\//, '') || '';
+
+      // Upvotes — Reddit renders these in various elements
+      const voteEl = container.querySelector('faceplate-number[pretty]')
+        || container.querySelector('[id*="vote-score"]')
+        || container.querySelector('shreddit-post')
+        || container.querySelector('[score]');
+      let upvotes = 0;
+      if (voteEl) {
+        const raw = voteEl.getAttribute('pretty')
+          || voteEl.getAttribute('score')
+          || voteEl.textContent?.trim();
+        upvotes = parseVoteString(raw);
+      }
+
+      // Comment count
+      const commentEl = container.querySelector('a[href*="/comments/"] span')
+        || container.querySelector('[data-testid="comment-count"]');
+      let comments = 0;
+      if (commentEl) {
+        const match = commentEl.textContent?.match(/(\d+)/);
+        comments = match ? parseInt(match[1], 10) : 0;
+      }
+
+      // Timestamp
+      const timeEl = container.querySelector('time, faceplate-timeago');
+      const timestamp = timeEl?.getAttribute('datetime')
+        || timeEl?.getAttribute('ts')
+        || timeEl?.textContent?.trim()
+        || '';
+
+      // Subreddit (may differ from search target if cross-posted)
+      const subEl = container.querySelector('a[href*="/r/"]');
+      const subreddit = subEl?.textContent?.trim() || '';
+
+      posts.push({ title, author, url, upvotes, comments, timestamp, subreddit, postId });
+    } catch (e) {
+      // Skip malformed entries
+    }
+  });
+
+  function parseVoteString(str) {
+    if (!str) return 0;
+    str = str.trim().toLowerCase();
+    if (str.endsWith('k')) return Math.round(parseFloat(str) * 1000);
+    if (str.endsWith('m')) return Math.round(parseFloat(str) * 1000000);
+    return parseInt(str.replace(/,/g, ''), 10) || 0;
+  }
+
+  return posts;
+})()
+```
+
+### Filter Results
+
+After extraction, apply in the skill logic (not in JS):
+- Skip posts with `upvotes < engagement_threshold` (default: 10)
+- Rank by `comments` descending (more comments = more potential quotes)
+- Select top N (default: 10 per subreddit)
+
+---
+
+## Thread Page (Post + Comments)
+
+Navigate to the thread URL from search results.
+
+### Scroll and Load Comments
+
+Reddit lazy-loads comments. Use `browser_run_code` to scroll incrementally:
+
+```javascript
+// Scroll to load comments — run via browser_run_code
+// Scrolls 700px at a time with 750ms pauses
+// Returns the final scroll height for verification
+(async () => {
+  const scrollStep = 700;
+  const pauseMs = 750;
+  const maxScrolls = 20; // Safety cap: 20 * 700 = 14000px
+
+  let scrolls = 0;
+  let lastHeight = document.body.scrollHeight;
+
+  while (scrolls < maxScrolls) {
+    window.scrollBy(0, scrollStep);
+    await new Promise(r => setTimeout(r, pauseMs));
+
+    const newHeight = document.body.scrollHeight;
+    // Stop if we've reached the bottom (no new content loaded)
+    if (newHeight === lastHeight) {
+      // One more try in case of slow load
+      await new Promise(r => setTimeout(r, 1500));
+      if (document.body.scrollHeight === lastHeight) break;
+    }
+    lastHeight = document.body.scrollHeight;
+    scrolls++;
+  }
+
+  // Scroll back to top so snapshot is from the beginning
+  window.scrollTo(0, 0);
+  return { scrolls, finalHeight: document.body.scrollHeight };
+})()
+```
+
+### Extract Post Metadata
+
+Pass to `browser_evaluate`:
+
+```javascript
+// Extract the original post's metadata
+(() => {
+  const post = {};
+
+  // Title
+  const titleEl = document.querySelector('[id*="post-title"]')
+    || document.querySelector('shreddit-post [slot="title"]')
+    || document.querySelector('h1');
+  post.title = titleEl?.textContent?.trim() || '';
+
+  // Author
+  const authorEl = document.querySelector('shreddit-post a[href*="/user/"]')
+    || document.querySelector('[data-testid="post-author"]');
+  post.author = authorEl?.textContent?.trim()?.replace(/^u\//, '') || '';
+
+  // Post body text (self-post)
+  const bodyEl = document.querySelector('[id*="post-rtjson-content"]')
+    || document.querySelector('shreddit-post [slot="text-body"]')
+    || document.querySelector('[data-testid="post-content"]');
+  post.body = bodyEl?.textContent?.trim() || '';
+
+  // Upvotes on the post itself
+  const voteEl = document.querySelector('shreddit-post faceplate-number[pretty]')
+    || document.querySelector('shreddit-post [score]');
+  const raw = voteEl?.getAttribute('pretty') || voteEl?.getAttribute('score') || '0';
+  post.upvotes = parseVoteString(raw);
+
+  // Comment count
+  const commentEl = document.querySelector('[id*="comment-count"]')
+    || document.querySelector('shreddit-post [slot="commentCount"]');
+  const cMatch = commentEl?.textContent?.match(/(\d+)/);
+  post.commentCount = cMatch ? parseInt(cMatch[1], 10) : 0;
+
+  // Timestamp
+  const timeEl = document.querySelector('shreddit-post time, shreddit-post faceplate-timeago');
+  post.timestamp = timeEl?.getAttribute('datetime') || timeEl?.getAttribute('ts') || '';
+
+  // Subreddit
+  const subEl = document.querySelector('shreddit-post a[href*="/r/"]');
+  post.subreddit = subEl?.textContent?.trim() || '';
+
+  // URL
+  post.url = window.location.href;
+
+  function parseVoteString(str) {
+    if (!str) return 0;
+    str = str.trim().toLowerCase();
+    if (str.endsWith('k')) return Math.round(parseFloat(str) * 1000);
+    if (str.endsWith('m')) return Math.round(parseFloat(str) * 1000000);
+    return parseInt(str.replace(/,/g, ''), 10) || 0;
+  }
+
+  return post;
+})()
+```
+
+### Extract Comments
+
+Pass to `browser_evaluate`:
+
+```javascript
+// Extract all visible comments with metadata
+(() => {
+  const comments = [];
+
+  // Target shreddit comment trees
+  const commentEls = document.querySelectorAll('shreddit-comment');
+
+  // Fallback for older/different layouts
+  const targets = commentEls.length > 0
+    ? commentEls
+    : document.querySelectorAll('[data-testid="comment"], .Comment');
+
+  targets.forEach((el, index) => {
+    try {
+      // Comment text — look for the paragraph content
+      const contentEl = el.querySelector('[id*="comment-content"]')
+        || el.querySelector('[slot="comment"]')
+        || el.querySelector('[data-testid="comment"] p')
+        || el.querySelector('p');
+      const text = contentEl?.textContent?.trim() || '';
+
+      // Skip empty or very short comments (likely "[deleted]" or reactions)
+      if (!text || text.length < 20) return;
+
+      // Author
+      const author = el.getAttribute('author')
+        || el.querySelector('a[href*="/user/"]')?.textContent?.trim()?.replace(/^u\//, '')
+        || '';
+
+      // Depth (nesting level)
+      const depth = parseInt(el.getAttribute('depth') || '0', 10);
+
+      // Upvotes
+      const voteEl = el.querySelector('faceplate-number[pretty]')
+        || el.querySelector('[score]');
+      const raw = voteEl?.getAttribute('pretty') || voteEl?.getAttribute('score') || '0';
+      const upvotes = parseVoteString(raw);
+
+      // Timestamp
+      const timeEl = el.querySelector('time, faceplate-timeago');
+      const timestamp = timeEl?.getAttribute('datetime')
+        || timeEl?.getAttribute('ts')
+        || timeEl?.textContent?.trim()
+        || '';
+
+      // Permalink — construct from thing_id or comment ID
+      const thingId = el.getAttribute('thingid') || el.getAttribute('id') || '';
+      const permalink = thingId
+        ? `${window.location.href.split('?')[0]}${thingId}/`
+        : window.location.href;
+
+      // Count replies (direct children that are also comments)
+      const replyCount = el.querySelectorAll(':scope > shreddit-comment').length;
+
+      comments.push({
+        text,
+        author,
+        depth,
+        upvotes,
+        timestamp,
+        permalink,
+        replyCount,
+        index
+      });
+    } catch (e) {
+      // Skip malformed comments
+    }
+  });
+
+  function parseVoteString(str) {
+    if (!str) return 0;
+    str = str.trim().toLowerCase();
+    if (str.endsWith('k')) return Math.round(parseFloat(str) * 1000);
+    if (str.endsWith('m')) return Math.round(parseFloat(str) * 1000000);
+    return parseInt(str.replace(/,/g, ''), 10) || 0;
+  }
+
+  return comments;
+})()
+```
+
+---
+
+## "Same Here" Detection
+
+After extracting comments, count agreement replies for each top-level pain comment. Pass to `browser_evaluate` with a target comment's index:
+
+```javascript
+// Count "same here" style agreement in replies to a specific comment
+// Pass parentIndex as a variable or inline it before evaluation
+((parentIndex) => {
+  const allComments = document.querySelectorAll('shreddit-comment');
+  const parent = allComments[parentIndex];
+  if (!parent) return { sameHereCount: 0, agreementReplies: [] };
+
+  const replies = parent.querySelectorAll(':scope > shreddit-comment');
+  const agreementPatterns = [
+    /\bsame\b/i,
+    /\bthis\b/i,
+    /\bexactly\b/i,
+    /\b100%\b/i,
+    /\bpreach\b/i,
+    /\bso much this\b/i,
+    /\bcan confirm\b/i,
+    /\bme too\b/i,
+    /\bi feel this\b/i,
+    /\bhappened to me\b/i,
+    /\bsame boat\b/i,
+    /\bsame experience\b/i,
+    /\bgoing through this\b/i,
+    /\bi thought i was the only one\b/i,
+    /^\+1$/i,
+    /^this\.?$/i,
+    /^same\.?$/i
+  ];
+
+  const agreementReplies = [];
+  replies.forEach(reply => {
+    const text = reply.querySelector('[id*="comment-content"], [slot="comment"], p')
+      ?.textContent?.trim() || '';
+    if (text.length < 100 && agreementPatterns.some(p => p.test(text))) {
+      agreementReplies.push(text);
+    }
+  });
+
+  return {
+    sameHereCount: agreementReplies.length,
+    agreementReplies
+  };
+})
+```
+
+> **Usage note**: Call this as a function literal. To invoke, wrap in an IIFE with the parentIndex: `(${script})(${idx})`. Or use `browser_evaluate` with the parentIndex inlined.
+
+---
+
+## Pain Category Keyword Matcher
+
+Use this client-side to auto-suggest a `pain_category` for each harvested quote. The skill operator should verify/override.
+
+```javascript
+// Auto-suggest pain category from quote text
+// Returns best-match category or "uncategorized"
+((quoteText) => {
+  const text = quoteText.toLowerCase();
+
+  const categories = {
+    'tutorial-gap': [
+      'tutorial', 'course', 'hello world', 'getting started',
+      'beginner', 'after the tutorial', 'tutorial hell',
+      'every tutorial', 'no tutorial', 'step by step'
+    ],
+    'tool-complexity': [
+      'too complex', 'overcomplicated', 'overkill', 'bloated',
+      'why is it so', 'steep learning curve', 'abstraction',
+      'configuration', 'boilerplate', 'ceremony'
+    ],
+    'real-world-gap': [
+      'production', 'real world', 'enterprise', 'at scale',
+      'not hello world', 'actual project', 'in practice',
+      'real app', 'professional', 'team environment'
+    ],
+    'career-transition': [
+      'career', 'transition', 'switch', 'break into',
+      'junior', 'entry level', 'hire', 'job market',
+      'career change', 'getting into'
+    ],
+    'information-overload': [
+      'overwhelmed', 'too many', 'which one', 'overload',
+      'where do i start', 'roadmap', 'so many options',
+      'decision fatigue', 'paradox of choice', 'confused by'
+    ],
+    'environment-setup': [
+      'setup', 'install', 'configure', 'environment',
+      'local dev', 'docker compose', 'works on my machine',
+      'dependency', 'version', 'compatibility'
+    ],
+    'debugging-hell': [
+      'debugging', 'debug', 'error', 'spent hours',
+      'spent days', 'can\'t figure', 'stack trace',
+      'cryptic', 'error message', 'silent fail'
+    ],
+    'missing-fundamentals': [
+      'fundamentals', 'basics', 'foundation', 'underlying',
+      'don\'t understand why', 'how does it actually',
+      'under the hood', 'conceptually', 'mental model'
+    ]
+  };
+
+  let bestCategory = 'uncategorized';
+  let bestScore = 0;
+
+  for (const [category, keywords] of Object.entries(categories)) {
+    let score = 0;
+    for (const kw of keywords) {
+      if (text.includes(kw)) score++;
+    }
+    if (score > bestScore) {
+      bestScore = score;
+      bestCategory = category;
+    }
+  }
+
+  return bestCategory;
+})
+```
+
+> **Usage note**: Same invocation pattern as the "same here" detector. Pass quote text as the argument.
+
+---
+
+## Troubleshooting
+
+### Selectors returning empty results
+
+Reddit ships multiple frontends. If selectors break:
+
+1. Use `browser_snapshot` to get the current accessibility tree
+2. Look for `shreddit-comment`, `faceplate-tracker`, or `search-telemetry-tracker` custom elements
+3. If none found, Reddit may have rolled out a new frontend — use `browser_evaluate` with `document.querySelectorAll('*')` filtered by tag prefix to discover new custom element names
+4. Update selectors in this file accordingly
+
+### Comment loading issues
+
+- Reddit caps visible comments. If a thread has 500+ comments but only 20 load, use `browser_click` on "More comments" / "Continue thread" links before extracting
+- Pattern for "load more" buttons: `button[id*="comment-tree-content-anchor"]`, `[data-testid="load-more-comments"]`, or links containing "more replies"
+
+### Login-gated content
+
+Some subreddit searches or NSFW threads require login. The skill assumes you're logged in before invoking. If `browser_evaluate` returns empty on a page that should have content, verify login state:
+
+```javascript
+// Check if logged in
+(() => {
+  const userMenu = document.querySelector('[id*="USER_DROPDOWN"]')
+    || document.querySelector('header a[href*="/user/"]');
+  return { loggedIn: !!userMenu };
+})()
+```

--- a/skills/custom/reddit-harvest/references/subreddit-targets.md
+++ b/skills/custom/reddit-harvest/references/subreddit-targets.md
@@ -1,0 +1,84 @@
+# Subreddit Targets
+
+Priority subreddits for pain-quote harvesting, organized by domain. DevOps is primary — start there. Expand to secondary/tertiary as the content pipeline demands.
+
+---
+
+## DevOps / Infrastructure (Primary)
+
+These are the first subreddits to harvest. The brand thesis ("I finished the tutorial. Now what?") hits hardest here.
+
+| Subreddit | Members (approx) | Why It's High-Value | Best Pain Queries |
+|-----------|------------------|---------------------|-------------------|
+| r/devops | 300K+ | Core audience. Practitioners venting about tooling, process, learning gaps. | "tutorial", "production", "where do I start", "career" |
+| r/kubernetes | 250K+ | K8s is the #1 complained-about tool in DevOps education. Gold mine. | "learning curve", "yaml", "networking", "debugging" |
+| r/docker | 200K+ | First DevOps tool most people learn. Beginner pain is concentrated here. | "beginner", "compose", "networking", "works on my machine" |
+| r/terraform | 100K+ | State management, modules, team workflows — rich specific pain. | "state", "modules", "best practices", "team" |
+| r/aws | 350K+ | Cloud-first pain. IAM, networking, cost. Huge audience. | "confusing", "expensive", "certification", "networking" |
+| r/sysadmin | 500K+ | Old-school ops transitioning to DevOps. Career-transition pain. | "devops", "automation", "learning", "career change" |
+| r/homelab | 350K+ | Hobbyists hitting production-grade problems for the first time. | "how do you", "setup", "docker", "kubernetes" |
+| r/selfhosted | 300K+ | Self-starters trying to run real infrastructure. Config & debug pain. | "struggling", "setup", "alternative", "networking" |
+| r/ansible | 50K+ | Automation-specific pain. Configuration management is a common gap. | "playbook", "best practice", "learning", "complex" |
+
+### DevOps Search Priority Order
+
+Run searches in this order to maximize yield per session:
+
+1. **r/devops** — broadest, highest general pain density
+2. **r/kubernetes** — deepest, most specific pain
+3. **r/terraform** — state management is a proven gold theme
+4. **r/aws** — massive audience, IAM/networking pain
+5. **r/docker** — beginner-heavy, tutorial-gap pain
+6. **r/sysadmin** — career-transition pain
+7. **r/homelab + r/selfhosted** — real-world gap pain (hobbyists hitting production problems)
+8. **r/ansible** — niche but specific
+
+---
+
+## Programming / Learning (Secondary)
+
+Harvest these when expanding beyond DevOps or when the content pipeline needs programming-focused quotes.
+
+| Subreddit | Members (approx) | Why It's High-Value | Best Pain Queries |
+|-----------|------------------|---------------------|-------------------|
+| r/learnprogramming | 4M+ | Massive beginner audience. Tutorial-hell quotes flow freely. | "tutorial hell", "stuck", "after the course", "real project" |
+| r/webdev | 1M+ | Frontend/fullstack pain. Deployment, tooling complexity, framework fatigue. | "overwhelmed", "which framework", "deployment", "too many" |
+| r/node | 150K+ | Node.js specific. Async pain, tooling, production gaps. | "async", "debugging", "production", "best practice" |
+| r/reactjs | 400K+ | React-specific. State management, build tooling, testing gaps. | "state management", "testing", "build", "why is it" |
+| r/golang | 200K+ | Go learners. Error handling, concurrency, "the Go way" confusion. | "error handling", "channels", "idiomatic", "coming from" |
+| r/rust | 300K+ | Rust learners. Borrow checker, lifetime, learning curve legendarily painful. | "borrow checker", "lifetime", "learning curve", "fighting" |
+| r/python | 1M+ | Broad. Best for beginner pain and "Python in production" gaps. | "beginner", "project", "production", "packaging" |
+
+---
+
+## Cybersecurity (Tertiary)
+
+Third priority per the domain roadmap. Harvest when ready to build cybersec content.
+
+| Subreddit | Members (approx) | Why It's High-Value | Best Pain Queries |
+|-----------|------------------|---------------------|-------------------|
+| r/netsec | 500K+ | Practitioner-level security. Deep technical pain. | "learning", "career", "where to start", "resources" |
+| r/cybersecurity | 300K+ | Broad cybersec audience. Career-transition pain dominant. | "break into", "career change", "certification", "overwhelmed" |
+| r/AskNetsec | 100K+ | Q&A format — direct pain statements. | "how do I", "where to start", "recommend", "frustrated" |
+| r/blueteam | 30K+ | Defensive security. SOC analyst pain, tooling gaps. | "soc", "alert fatigue", "learning", "tools" |
+
+---
+
+## Cross-Domain (Bonus)
+
+These subreddits surface pain that spans multiple domains:
+
+| Subreddit | Why |
+|-----------|-----|
+| r/ExperiencedDevs | Mid-to-senior engineers. "I've been doing this for years and..." pain. Higher specificity. |
+| r/cscareerquestions | Career-oriented pain. Less useful for repo content, but good for understanding audience motivations. |
+| r/ITCareerQuestions | IT/ops career transitions. Overlaps with sysadmin → DevOps journey. |
+
+---
+
+## Usage Notes
+
+- **Start narrow, expand if needed.** For a focused DevOps scan, hit r/devops + r/kubernetes + r/terraform. Only expand if quote yield is low.
+- **Niche subreddits have higher signal-to-noise.** 30 upvotes on r/terraform (100K members) is more significant than 30 upvotes on r/programming (6M members). Adjust engagement scoring per the scoring rubric's community-size guidance.
+- **Check subreddit rules before any future posting.** This file is for harvesting only. Some subreddits have strict self-promotion rules relevant to the content distribution phase.
+- **Seasonal patterns.** Pain posts spike in January (New Year resolutions), September (back to school/new jobs), and during major tool releases (K8s versions, Terraform provider updates). Time scans accordingly.


### PR DESCRIPTION
## Summary

- Adds `reddit-harvest` skill that uses Playwright MCP to drive a logged-in Reddit browser session for pain-quote harvesting
- Outputs in wild-scan format (`output-schema.json`) — no new schemas, no changes to existing files
- Includes Reddit DOM extraction JS snippets (`selectors.md`) and priority subreddit targets by domain (`subreddit-targets.md`)

Closes #10

## What it does

wild-scan can't reliably reach Reddit via `site:reddit.com` web search (queries get blocked). reddit-harvest solves this with a 5-phase Playwright-driven workflow:

1. **Search** — Navigate to subreddit search URLs with pain-language queries
2. **Scan** — Extract post metadata, filter by engagement, rank by comment count
3. **Harvest** — Click into threads, scroll to load comments, extract quotes with full metadata
4. **Score** — Apply wild-scan's 4-dimension rubric (specificity, intensity, solvability, engagement)
5. **Export** — Write Markdown + JSON to vault in wild-scan format

## Test plan

- [ ] Verify selectors.md JS snippets work on current Reddit DOM via Playwright MCP
- [ ] Run end-to-end harvest on r/devops for a test topic
- [ ] Validate JSON output against `wild-scan/references/output-schema.json`
- [ ] Confirm Markdown output has correct frontmatter per `_conventions.md`
- [ ] Feed output into wild-scan Phase 4 (theme clustering) to verify pipeline integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)