### PR TITLE
feat: add job-search skill

### DIFF
--- a/skills/custom/job-search/README.md
+++ b/skills/custom/job-search/README.md
@@ -1,0 +1,24 @@
+# Job Search Pipeline
+
+Structured profiles, search criteria, and tracking for the 2026 job search.
+
+## Profiles
+
+Each profile is a "view" over the same experience, optimized for a specific role archetype.
+The resume and cover letter stay the same; the *emphasis* shifts.
+
+| Profile | File | Target roles |
+|---------|------|-------------|
+| Research Engineer | `profiles/research-engineer.md` | RE, applied ML research, eval design |
+| Infrastructure / Platform | `profiles/infrastructure.md` | Platform eng, infra, SRE, distributed systems |
+| ML / AI Engineer | `profiles/ml-engineer.md` | MLE, applied AI, retrieval, NLP |
+| Developer Tools / DevEx | `profiles/dev-tools.md` | DevTools, SDK, open-source, DX |
+| Product Engineer | `profiles/product-engineer.md` | Full-stack, product eng, early-stage |
+
+## Tracking
+
+Kanban lives in Obsidian: `ClawTheCurious/Job Search/kanban.md`
+
+## Search
+
+Target companies and criteria in `targets.md`.

--- a/skills/custom/job-search/SKILL.md
+++ b/skills/custom/job-search/SKILL.md
@@ -1,0 +1,297 @@
+---
+name: job-search
+description: "Job search pipeline — scan for matching roles, sort by interview readiness, generate tailored application briefs, prep submission-ready packages, and track status. Each brief projects the same experience through the lens most relevant to the specific role."
+license: MIT
+metadata:
+  openclaw:
+    emoji: "\U0001F3AF"
+---
+
+# Job Search Pipeline
+
+Structured job search workflow: scan → sort → brief → package → apply → track.
+
+## When to Use
+
+- Scanning for matching roles across career pages, HN, job boards
+- Sorting roles by interview readiness (not just fit)
+- Generating tailored application briefs for specific roles
+- Creating submission-ready application packages (cover letter, form notes, prep sheet)
+- Tracking application status across the pipeline
+
+## Trigger Phrases
+
+- "Scan for matching roles"
+- "Sort by interview readiness"
+- "Generate a brief for [company]"
+- "Prep application package for [company]"
+- "Update job search status"
+- "/job-search scan"
+- "/job-search sort"
+- "/job-search brief [company]"
+- "/job-search package [company]"
+
+---
+
+## Architecture
+
+### Profiles (5 archetypes)
+
+Each profile is a "view" over the same experience, optimized for a role archetype.
+The resume stays the same; the *emphasis* shifts.
+
+| Profile | File | Leads with |
+|---------|------|-----------|
+| Research Engineer | `profiles/research-engineer.md` | Thompson Sampling, agent learning, evaluation |
+| Infrastructure | `profiles/infrastructure.md` | Distributed systems, containment, observability |
+| ML / AI Engineer | `profiles/ml-engineer.md` | Retrieval quality, knowledge graphs, benchmarks |
+| Developer Tools | `profiles/dev-tools.md` | Framework adapters, MCP, SDK design |
+| Product Engineer | `profiles/product-engineer.md` | End-to-end shipping, interactive UI, NLP apps |
+
+### Application Briefs (`applications/`)
+
+Per-company briefs that map candidate strengths to role requirements.
+
+Each brief contains:
+- **Lead profile** — which archetype to emphasize
+- **Tailored pitch** — 2-3 sentences for this specific role
+- **Resume emphasis** — reordered project list for this role
+- **"Why this role"** — authentic, specific motivation
+- **Proof point mapping** — which evidence matches which requirements
+- **Gap analysis** — what's weak and how to frame it
+- **"If they ask X, say Y"** — role-specific interview prep
+
+### Application Packages (`applications/*-READY.md`)
+
+Submission-ready packages built from briefs. Each contains:
+- **Cover letter** — 300-400 words, specific, no generic filler
+- **Application form notes** — pre-filled field values for the platform (Greenhouse/Lever/Ashby)
+- **Key links** — portfolio, GitHub, PyPI, articles
+- **Interview prep quick sheet** — 5 Q&A pairs, 30-second pitch, question to ask them
+- **Pre-submission checklist** — verify before hitting send
+
+### Tracking
+
+- **Targets**: `targets.md` — search results, company list, links
+- **Kanban**: Obsidian `ClawTheCurious/Job Search/kanban.md`
+- **Statuses**: Researching → Preparing → Applied → Interviewing → Offer → Closed
+
+---
+
+## Workflow: Scan
+
+Search for matching roles across sources.
+
+1. Load profiles to understand candidate strengths
+2. Search career pages (Tier 1 weekly, Tier 2 biweekly)
+3. Search HN "Who's Hiring" (monthly)
+4. Score each role against profiles (1-5 fit)
+5. Update `targets.md` with results and links
+6. Update Obsidian kanban with new entries
+
+Sources:
+- Company career pages (Greenhouse, Ashby, Lever, Workable)
+- Hacker News "Who's Hiring" thread
+- Y Combinator Work at a Startup
+- LinkedIn job alerts
+
+---
+
+## Workflow: Sort
+
+After scanning, sort roles by **interview readiness** — not just fit score.
+
+A 5/5 fit role with a DSA-heavy interview the candidate would fail is LESS valuable than a 4/5 fit role with a portfolio-based interview they'd crush.
+
+### Sort Dimensions
+
+| Dimension | Weight | What It Measures |
+|-----------|--------|-----------------|
+| Fit score | 2x | How well the role matches candidate strengths |
+| Interview style match | 2x | Practical/portfolio vs DSA/competitive vs mixed |
+| Speed to offer | 1x | How fast the company typically moves |
+| Comp adequacy | 1x | Meets the floor for the location |
+| Location fit | 1x | Remote > willing-to-relocate > hard-no |
+
+### Interview Style Categories
+
+| Category | Description | Candidate Readiness |
+|----------|-------------|-------------------|
+| **Portfolio/practical** | Look at your GitHub, discuss your projects, pair-program on real code | Strongest — the work speaks |
+| **System design** | Design a system on a whiteboard in 45 min | Moderate — can do it, needs practice articulating under time pressure |
+| **Take-home** | Build something in 4-8 hours, discuss it | Strong — this is what the candidate does daily |
+| **ML concepts** | Discuss ML fundamentals, explain your research | Moderate — uses the concepts, needs to be crisper on vocabulary |
+| **DSA/leetcode** | Solve algorithmic problems under time pressure | Weakest — needs dedicated ramp time |
+| **Math/theory** | Prove convergence, derive equations, discuss proofs | Weakest — practitioner, not theoretician |
+
+### Sort Output
+
+Produce a ranked list with readiness tier:
+
+```markdown
+| Rank | Company | Role | Fit | Interview Style | Readiness | Priority |
+|------|---------|------|-----|----------------|-----------|----------|
+| 1 | {company} | {role} | {n}/5 | Portfolio/practical | Ready now | Apply this week |
+| 2 | {company} | {role} | {n}/5 | System design + practical | 2-4 weeks prep | Apply after prep |
+| ... | ... | ... | ... | ... | ... | ... |
+```
+
+### When to Sort
+
+- After every scan (sort the new results)
+- When candidate's readiness changes (DSA improves → re-sort)
+- When urgency changes (need income NOW → weight speed-to-offer higher)
+
+---
+
+## Workflow: Brief
+
+Generate a tailored application brief for a specific role.
+
+1. Read the role requirements (from targets.md link or provided JD)
+2. Select lead profile based on role requirements
+3. Map candidate proof points to role requirements
+4. Generate tailored pitch, resume emphasis, and talking points
+5. Identify gaps and prepare framing
+6. Write brief to `applications/{company-slug}.md`
+
+### Brief Template
+
+```markdown
+# {Company} — {Role Title}
+
+## Role Summary
+- **Link**: {job posting URL}
+- **Location**: {location}
+- **Comp**: {compensation range}
+- **Fit Score**: {N}/5
+
+## Lead Profile
+{which profile to emphasize and why}
+
+## Tailored Pitch (2-3 sentences)
+{pitch mapped to this role's specific needs}
+
+## Resume Emphasis
+1. {project — why it matters for this role}
+2. {project — why it matters for this role}
+3. ...
+
+## Proof Point Mapping
+| Requirement | Evidence | Strength |
+|-------------|----------|----------|
+| {requirement from JD} | {specific proof point} | strong/moderate/developing |
+
+## Why This Role (authentic)
+{genuine motivation — not boilerplate}
+
+## Gap Analysis
+| Gap | How to Frame |
+|-----|-------------|
+| {missing skill/experience} | {honest framing + growth trajectory} |
+
+## If They Ask X, Say Y
+- **"{likely question}"** → {prepared response}
+- **"{likely question}"** → {prepared response}
+
+## Application Notes
+{any special instructions, referrals, timing}
+```
+
+---
+
+## Workflow: Package
+
+Generate a submission-ready application package from an existing brief.
+
+1. Read the brief (`applications/{company-slug}.md`)
+2. Fetch the actual job posting for application form details
+3. Draft cover letter from brief hooks (300-400 words, specific, no filler)
+4. Map application form fields (Greenhouse/Lever/Ashby standard fields)
+5. Compile key links (portfolio, GitHub, PyPI, articles)
+6. Create interview prep quick sheet (5 Q&A, 30-second pitch, question to ask)
+7. Write package to `applications/{company-slug}-READY.md`
+
+### Package Template
+
+```markdown
+# {Company} — {Role Title} — Application Package
+
+## Cover Letter
+{300-400 words. Every sentence references a specific project or number.
+No "I'm passionate about..." — use the role's own language.}
+
+## Application Form Notes
+| Field | Value |
+|-------|-------|
+| Name | Peleke Sengstacke |
+| Portfolio | https://peleke.dev |
+| GitHub | https://github.com/Peleke |
+| {platform-specific fields} | {values} |
+
+## Key Links
+| Link | What It Shows |
+|------|--------------|
+| {url} | {what the reviewer will see} |
+
+## Interview Prep Quick Sheet
+
+### 30-Second Pitch
+{tailored to this company}
+
+### Most Likely Questions
+1. **"{question}"** → {crisp answer, 2-3 sentences}
+...
+
+### Question to Ask Them
+{one question that shows you've done homework}
+
+## Pre-Submission Checklist
+- [ ] Job posting still live
+- [ ] Cover letter references this specific role (not generic)
+- [ ] All links work
+- [ ] Resume attached
+- [ ] Portfolio is clean and loads fast
+```
+
+### Cover Letter Rules
+
+- Open with the strongest hook from the brief
+- Every sentence must reference a specific project, number, or proof point
+- Address the Go/Rust/language gap honestly if applicable (one sentence, not apologetic)
+- Close with why THIS company, THIS team — not "I love AI"
+- Tone: practitioner writing to practitioners
+- 300-400 words. Not longer. Respect their time.
+
+---
+
+## Workflow: Track
+
+Update application status across tracking surfaces.
+
+1. Move kanban card to new column
+2. Update targets.md status
+3. Add notes (interview dates, feedback, next steps)
+
+---
+
+## Assets
+
+- `assets/proof-points.md` — Master list of citable evidence with numbers
+- `assets/anthropic-ramp.md` — 6-9 month interview prep plan for Anthropic
+- `profiles/*.md` — Role archetypes with pitches and emphasis orders
+- `targets.md` — Company list with search results and links
+
+---
+
+## Quality Checklist
+
+- [ ] Every brief maps to a specific lead profile
+- [ ] Pitch uses the role's own language, not generic
+- [ ] Proof points are specific numbers, not hand-wavy claims
+- [ ] Gap analysis is honest — don't claim expertise you don't have
+- [ ] "Why this role" is authentic and role-specific
+- [ ] Interview prep covers likely technical deep-dives
+- [ ] Sort accounts for interview readiness, not just fit
+- [ ] Package cover letter has zero generic sentences
+- [ ] Kanban and targets.md stay in sync

--- a/skills/custom/job-search/applications/anthropic-ai-observability.md
+++ b/skills/custom/job-search/applications/anthropic-ai-observability.md
@@ -1,0 +1,70 @@
+# Anthropic — Research Engineer, AI Observability
+
+## Role Summary
+- **Link**: https://job-boards.greenhouse.io/anthropic/jobs/5125083008
+- **Location**: San Francisco, CA (hybrid, 25% in-office)
+- **Comp**: $320,000 - $405,000
+- **Fit Score**: 5/5
+
+## Lead Profile
+Lead with **Research Engineer**, blended with **Infrastructure**. This role lives at the intersection of measurement and systems — the team builds AI-based monitoring to help Anthropic understand massive datasets and surface patterns in unstructured data. The observability stack (qortex-observe) and the retrieval quality measurement pipeline are direct analogs. The research angle matters because the team designs analytical frameworks, not just dashboards.
+
+## Tailored Pitch (2-3 sentences)
+I built the observability pipeline I'd want to use on this team: OpenTelemetry traces spanning query through retrieval through graph exploration through feedback, with Grafana dashboards tracking posterior drift and retrieval quality degradation in real time. The measurement discipline carries — qortex's benchmark suite produces precision, recall, and nDCG numbers against a controlled domain, not vibes. I want to apply that same rigor to monitoring Claude's behavior at scale.
+
+## Resume Emphasis
+1. **qortex-observe** — Full OTel instrumentation pipeline (Grafana, Jaeger, Prometheus) tracing agent behavior from query to retrieval to feedback. Direct analog to monitoring AI systems at scale.
+2. **qortex retrieval evaluation** — Closed-loop measurement: +22% precision, +26% recall, +14% nDCG on a controlled 20-concept benchmark. Evidence of building evaluation frameworks, not just features.
+3. **Thompson Sampling / posterior analysis** — 30 days of production posterior divergence data. Experience processing and analyzing large volumes of unstructured signal to surface unexpected patterns.
+4. **Framework adapters** — 7 frameworks with 100+ CI tests. Demonstrates building usable tools across ecosystems with reliability and documentation emphasis.
+5. **buildlog** — 16K-line developer workflow system with gauntlet review. Experience productionizing internal tools, plus an honest lesson about knowing when the approach is wrong.
+6. **edX + linguistics** — Education platform at scale (large-scale data processing context) and philology background (systematic analysis of unstructured text is literally the training).
+
+## Proof Point Mapping
+| Requirement | Evidence | Strength |
+|-------------|----------|----------|
+| 5+ years SWE with ML exposure | Agent systems with Thompson Sampling, Beta-Bernoulli posteriors, PPR graph algorithms. Prior edX platform engineering. | strong |
+| LLM application development (context engineering, evaluation, orchestration) | qortex is a context engineering system — retrieval + graph explore + feedback loop. 7 framework adapters handle orchestration. Evaluation: precision/recall/nDCG benchmark suite. | strong |
+| Monitoring/observability systems | qortex-observe: OTel traces from query → retrieval → graph explore → feedback. Grafana dashboards, Jaeger traces, Prometheus metrics. | strong |
+| Large-scale data processing | OTel instrumentation generating structured telemetry across agent workflows. edX content delivery at scale. Posterior analysis over 30 days of production data. | moderate |
+| Productionizing internal tools | bilrost published on PyPI, single-command provisioning. buildlog: git hooks + gauntlet review integrated into developer workflow. MCP server: 29 tool calls in 3.94s. | strong |
+| Context-switching infrastructure ↔ product thinking | Built both the OTel pipeline (infrastructure) and the retrieval quality dashboard (product). bilrost is infrastructure; framework adapters are product surface. | strong |
+| AI safety / responsible deployment | bilrost STRIDE threat model for agent containment. Sandbox with per-tool network isolation. The observability work is motivated by making agent behavior auditable. | moderate |
+| Comfort with ambiguity in small, growing teams | Every project is 0-to-1. qortex, bilrost, Vindler — all built from scratch without a playbook. buildlog was 16K lines exploring the wrong abstraction, and that's fine. | strong |
+
+## Why This Role (authentic)
+The AI Observability team is building the thing I've been building for myself: instrumentation that makes agent behavior legible. When I built qortex-observe, it was because I needed to answer "is the retrieval getting better or worse?" in real time — posterior drift on a dashboard instead of running a benchmark suite manually. Anthropic is the right place because the scale is different: monitoring Claude's behavior across deployments is the version of this problem that actually matters. The team description mentions "autonomous investigation and action on findings," which is exactly the agentic loop I've been studying — except applied to safety oversight instead of retrieval quality. That's a more important application.
+
+## Gap Analysis
+| Gap | How to Frame |
+|-----|-------------|
+| No experience at Anthropic-scale data volumes | The instrumentation patterns transfer — OTel is OTel. The gap is operational experience with petabyte-scale pipelines. Trajectory: actively working on distributed qortex service (REST/GraphQL, configurable storage backends). |
+| No formal AI safety research publications | The safety motivation is real but the credential is thin. Frame as: the work is safety-adjacent (agent containment, threat modeling, observability for auditability) even if not published in safety venues. |
+| Python/TypeScript, not yet proficient in languages Anthropic may use internally | Strong Python, strong TypeScript, learning Rust. The learning trajectory is toward systems languages. Ansible experience shows comfort with operational tooling. |
+| Team is "emerging" — may want someone with prior observability platform experience at a company | All observability work is self-directed, not on an observability team. Reframe: that means every design decision was mine, including the ones that were wrong. I know what I'd do differently. |
+
+## If They Ask X, Say Y
+- **"Walk me through your observability architecture."** → qortex-observe instruments four layers: query intake, vector retrieval, graph exploration (PPR + Thompson Sampling), and feedback recording. Each produces OTel spans with structured attributes — retrieval scores, edge weights, posterior parameters. Grafana dashboards show retrieval latency distributions and posterior drift over time. Jaeger gives per-query trace waterfall. The design choice was to make every signal a first-class span, not a log line, because spans compose and logs don't.
+
+- **"Why Anthropic? Why not stay independent?"** → Because the problem I care about — making AI systems legible and auditable — requires data I can't generate alone. Monitoring one agent's retrieval quality taught me the patterns. Monitoring Claude across millions of conversations is where those patterns actually produce safety outcomes. I want to work where the instrumentation matters most.
+
+- **"What's the hardest technical challenge you've faced?"** → Composing three retrieval signals (vector similarity, PPR, Thompson Sampling) into a single ranking without any of them dominating. The math is straightforward individually, but the weighting is an open design question. I solved it empirically: benchmark suite, controlled domain, ablation tests. The +22% precision came from getting the composition right, not from any one signal being better.
+
+- **"Tell me about a failure and what you learned."** → buildlog. 16K lines of Python building an LLM-as-judge review system. The gauntlet review layer works — rule-based, fast, useful. But the core hypothesis was wrong: the problem isn't "have an LLM review code," it's "select the right context for the right situation," which is a bandit problem. I scrapped the wrong part and kept what worked. The lesson: if your evaluation says the system works but you keep wanting to override it, the evaluation is measuring the wrong thing.
+
+- **"How do you work with researchers and cross-functional teams?"** → On Vindler, I worked across the agent runtime, sandbox, and observability layers — each with different constraints. The researchers care about retrieval quality, the platform team cares about latency, the safety team cares about auditability. OTel is the common language: everyone reads traces. I build the instrumentation so each team can ask their own questions without needing to understand the others' stack.
+
+- **"How do you think about scaling human oversight of AI?"** → You need three things: instrumentation that captures the right signals, aggregation that surfaces anomalies without drowning humans in noise, and interfaces that let investigators drill down when something looks wrong. qortex-observe does the first. The Anthropic AI Observability team is building all three at the scale that matters. My instinct is that the "surfacing anomalies" layer is where the hardest unsolved problems live — that's where retrieval quality measurement and posterior drift detection become directly applicable.
+
+## Cover Letter Hooks
+- When I built OpenTelemetry traces spanning every layer of an agent's retrieval pipeline — from query intake through graph exploration through feedback — I was solving the same problem your AI Observability team exists to solve: making AI behavior legible enough for humans to oversee.
+- The numbers tell a story about measurement discipline: +22% precision, +26% recall, +14% nDCG — not from a better embedding model, but from a feedback loop with Thompson Sampling on knowledge graph edges, validated on a controlled benchmark with distractors.
+- I built buildlog (16K lines), realized it was solving the wrong problem, scrapped the core, and kept the piece that worked — which taught me more about evaluation design than anything I shipped successfully.
+- My background in philology — systematic analysis of Latin and Old Norse texts — is surprisingly relevant to a team that processes massive volumes of unstructured text to surface unexpected patterns. Corpus analysis is corpus analysis.
+
+## Application Notes
+- This role is on an emerging team. Emphasize 0-to-1 experience and comfort with ambiguity in the application form.
+- The JD stresses "context engineering, evaluation, orchestration" — use those exact terms when describing qortex. Context engineering = retrieval + graph explore. Evaluation = benchmark suite. Orchestration = framework adapters.
+- Mention "human oversight of AI systems" explicitly — it's the team's north star.
+- The "agentic integrations enabling autonomous investigation" line maps directly to the agent runtime work (Vindler/openclaw). Call this out.
+- If there's a free-text field, lead with the qortex-observe story, not the retrieval quality story. This role is about monitoring, not about the thing being monitored.

--- a/skills/custom/job-search/applications/anthropic-platform-toolbox.md
+++ b/skills/custom/job-search/applications/anthropic-platform-toolbox.md
@@ -1,0 +1,73 @@
+# Anthropic — Software Engineer, Platform (Toolbox/MCP)
+
+## Role Summary
+- **Link**: https://job-boards.greenhouse.io/anthropic/jobs/4955107008
+- **Location**: NYC, San Francisco, or Seattle (hybrid, 25% in-office)
+- **Comp**: $320,000 - $405,000
+- **Fit Score**: 5/5
+
+## Lead Profile
+Lead with **Developer Tools / DevEx**, blended with **Infrastructure**. The Toolbox team builds "infrastructure that enables Claude to safely interact with the outside world through the use of tools" — this is MCP infrastructure, tool execution environments, and the platform layer connecting Claude to external services. The candidate builds MCP servers and framework adapters as a core activity, not a side project. The infrastructure angle matters for the sandbox and isolation work, but the primary story is: I build the protocol layer that connects agents to the world.
+
+## Tailored Pitch (2-3 sentences)
+I've been building on both sides of MCP: a cross-language stdio transport serving 29 tool calls in 3.94s, and 7 framework adapters that implement native interfaces for CrewAI, LangChain, Agno, AutoGen, Mastra, Smolagents, and LangChain.js — all passing framework-authored test suites. On the containment side, bilrost provides defense-in-depth agent sandboxing with per-tool network isolation, published on PyPI and deployable from a single CLI command. I want to build the platform that makes this safe connectivity the default, not something each team has to solve independently.
+
+## Resume Emphasis
+1. **MCP server** — Cross-language stdio transport bridging Python and TypeScript ecosystems. 29 tool calls in 3.94s with ~400ms server spawn. Direct experience with the protocol this team owns.
+2. **Framework adapters** — 7 agent frameworks, each implementing the framework's native interface. 100+ CI tests with latest-version pinning and zero-skip policy. Demonstrates building composable platform components serving multiple consumers.
+3. **bilrost** — Hardened VM sandbox for agent containment. Lima VM + OverlayFS + Docker dual-container isolation + gated sync. STRIDE threat model. PyPI published. Single CLI command. This is "secure, isolated execution environments" from the JD.
+4. **qortex distributed service** — Active work on REST/GraphQL API layer with configurable storage backends. Service-oriented architecture for the retrieval engine.
+5. **Vindler (openclaw)** — Agent runtime with OTel instrumentation. 90 merged PRs. Production system integration across sandbox, runtime, and observability layers.
+6. **edX** — Education platform engineering at scale. Experience with large codebases, cross-team collaboration, and shipping product to millions of users.
+
+## Proof Point Mapping
+| Requirement | Evidence | Strength |
+|-------------|----------|----------|
+| 6+ years distributed systems / backend engineering | MCP server (cross-language transport), qortex distributed service (REST/GraphQL), bilrost (VM provisioning + Docker isolation), edX platform. Agent runtime (Vindler) with 90 merged PRs. | strong |
+| Service-oriented architecture | qortex: retrieval engine with pluggable storage backends, adapter pattern for 7 frameworks. MCP: service boundary between agent and tools via stdio transport. bilrost: dual-container architecture with per-tool network policy. | strong |
+| 0-to-1 product building | Every project is greenfield. qortex, bilrost, Vindler, buildlog, MCP server — all designed, built, and shipped from scratch. | strong |
+| Fast-moving environment, navigating ambiguity | Built across 6+ projects simultaneously. buildlog: 16K lines, realized wrong approach, pivoted. Framework adapters: maintained against 7 upstream frameworks with breaking-change-same-day CI. | strong |
+| Full ownership mentality | PyPI published packages (qortex, bilrost). End-to-end: design, implement, test, document, ship, maintain. STRIDE threat model is self-initiated, not assigned. | strong |
+| Build vs. buy decisions | MCP stdio transport: built because no cross-language solution existed for our architecture. Chose Lima over raw QEMU for bilrost (simpler UX, sufficient isolation). Chose OTel over custom telemetry (standard wins). | strong |
+| REST API experience | qortex distributed service: REST/GraphQL API layer in active development. MCP server exposes tool schemas over JSON-RPC. | moderate |
+| NLP and ML model understanding | Thompson Sampling, Beta-Bernoulli posteriors, PPR on knowledge graphs. Linguistics background (Classical Latin, Old Norse). Not ML training, but principled ML application. | moderate |
+
+## Why This Role (authentic)
+I use MCP every day — not as an abstraction, but as a transport protocol I've implemented and debugged. When I built the qortex MCP server, I hit the real problems: stdio buffering across language boundaries, tool schema validation, server lifecycle management. The Toolbox team owns the infrastructure that makes Claude's tool use work, which means the problems are the same ones I've been solving, except at Anthropic scale with Anthropic constraints (security, reliability, latency budgets that matter). What's compelling is the mission beneath the platform: safe connectivity between Claude and the outside world. bilrost exists because I believe agent-tool interaction needs containment by default. This team is building that default for everyone.
+
+## Gap Analysis
+| Gap | How to Frame |
+|-----|-------------|
+| No experience at Anthropic's production scale | All current systems are single-developer, single-node. The patterns are sound (service boundaries, adapter pattern, transport abstraction), but haven't been tested at millions-of-requests scale. Frame as: the architectural instincts are there, the scale experience will come from the team. |
+| Rust is "learning," not "proficient" | Anthropic likely uses Rust for performance-critical platform components. Currently strong Python/TypeScript, actively learning Rust. Trajectory matters: the candidate learns new languages by building things (Interlinear: Icelandic NLP, framework adapters: 7 different APIs). |
+| No frontend/React experience listed | The JD lists React as preferred. This is genuinely a gap. Frame as: the candidate builds CLI tools and APIs, not UIs. If the role requires dashboard work, the ramp will be real but bounded — the data layer and API design skills transfer. |
+| No experience on a platform team at a company | All platform work is solo. No experience with platform team dynamics: on-call, SLA negotiation, internal customer management. edX is the closest analog for working in a large engineering org. |
+| Current work is stdio-based MCP, not the full protocol surface | MCP has HTTP/SSE transport, authentication, and features beyond stdio. Frame as: deep on one transport, aware of the protocol surface, ready to go deep on the rest. |
+
+## If They Ask X, Say Y
+- **"Walk me through your MCP implementation."** → The qortex MCP server exposes retrieval, feedback, and graph exploration as tool calls over stdio transport. The transport layer bridges Python (engine) and TypeScript (client ecosystem) — JSON-RPC over stdin/stdout with newline-delimited framing. Server lifecycle is managed per-session: spawn, handshake, tool discovery, execution, teardown. 29 tool calls in 3.94s including ~400ms spawn overhead. The design tradeoff was simplicity over performance — stdio is synchronous, which is fine when the LLM call downstream is 500ms-5s, but wouldn't scale for high-throughput scenarios. That's exactly why I'd want to work on the infrastructure that solves this properly.
+
+- **"Why Platform over Research?"** → Because the leverage is higher. A research breakthrough helps one team. A platform component that makes tool use secure and fast helps every team building on Claude. I've done both — the retrieval research (Thompson Sampling, PPR) and the platform work (MCP server, framework adapters, sandbox). The platform work compounds. When I ship an adapter, 7 frameworks gain the capability simultaneously. That's the kind of multiplication I want to do at Anthropic's scale.
+
+- **"Describe a technically challenging system you built from scratch."** → bilrost. The threat model came first: agents running arbitrary code need containment that doesn't depend on the agent cooperating. So: Lima VM for OS-level isolation, OverlayFS so filesystem mutations don't persist unless explicitly synced, Docker dual-container inside the VM (one for the agent runtime, one for tool execution), UFW firewall rules that default-deny and allowlist per-tool. The gated sync layer uses gitleaks to scan before anything leaves the sandbox. Single command to provision: `bilrost up`. The hardest part was making it feel simple — the user runs one command, but underneath it's Ansible provisioning a VM with Docker, configuring network policies, and setting up the sync pipeline.
+
+- **"Tell me about a time you had to make a build-vs-buy decision."** → For bilrost, the VM layer. Options: raw QEMU (maximum control, maximum complexity), Firecracker (fast boot, but overkill for dev sandboxes), Lima (macOS-native, good enough isolation, simple UX). Chose Lima because the containment model doesn't require microsecond boot times — it needs reliable isolation and developer ergonomics. The per-tool network isolation runs on UFW inside the VM, which is boring and correct. I'd rather have boring infrastructure that I can reason about than clever infrastructure that surprises me.
+
+- **"How do you handle maintaining compatibility across multiple consumers?"** → The framework adapter pattern. Each adapter implements the framework's native interface — LangChain's BaseRetriever, CrewAI's Tool, Agno's toolkit pattern. The CI runs each framework's own test suite against our adapter, pinned to the latest released version with a zero-skip policy. If CrewAI ships a breaking change on Monday, our CI fails on Monday. This is deliberate: I'd rather have a red build than a silent incompatibility. At Anthropic, the consumers would be internal teams instead of open-source frameworks, but the pattern is identical — implement their interface, test against their expectations, break loudly when the contract changes.
+
+- **"What's your experience with security and isolation?"** → STRIDE threat model for agent containment. I found that OpenClaw's identity layer was an attack surface — workspace files injected verbatim into system prompts. Rather than patch the injection point, I built containment: the sandbox can't exfiltrate data even if the agent is compromised, because network access is default-deny with per-tool allowlisting. 117 passing tests on the network isolation layer. The security philosophy is defense-in-depth: assume each layer will fail, make sure the next layer catches it.
+
+## Cover Letter Hooks
+- I've implemented MCP from both sides — a Python server exposing 29 tool calls over stdio transport, and framework adapters that let 7 agent ecosystems consume those tools through their native interfaces — so I know exactly where the protocol's current abstractions help and where they create friction.
+- bilrost provisions a hardened agent sandbox from a single CLI command: Lima VM, Docker dual-container isolation, per-tool network policy, gated sync with secret scanning — because I believe the platform that connects Claude to the outside world needs containment as a default, not an afterthought.
+- Maintaining 7 framework adapters against upstream breaking changes taught me what platform engineering actually requires: implement the consumer's interface, pass the consumer's tests, and break loudly the same day the contract changes.
+- The thread connecting my work — MCP transport, framework adapters, agent sandbox, observability pipeline — is that I keep building the infrastructure layer between AI systems and the world. The Toolbox team is where that work belongs.
+
+## Application Notes
+- The JD lists multiple platform sub-teams (Accel, Multicloud, Auth, Billing, Toolbox). Make clear in the application that Toolbox is the target — mention MCP by name.
+- Emphasize the "secure, isolated execution environments" language from the JD — bilrost maps directly.
+- "Composable platform components serving multiple use cases" is the adapter pattern. Use this exact framing.
+- The preferred qualifications include React — acknowledge this honestly as a gap if asked, don't pretend.
+- If there's a location preference field, NYC is probably strongest for this candidate if relocation flexibility exists. Note the role offers NYC, SF, or Seattle.
+- The "0-to-1 product building" requirement is the candidate's strongest differentiator. Every project is greenfield. Lead with this in any free-text field.
+- Mention PyPI publishing — it signals shipping culture, not just building culture.

--- a/skills/custom/job-search/applications/coder-ai-tools-READY.md
+++ b/skills/custom/job-search/applications/coder-ai-tools-READY.md
@@ -1,0 +1,99 @@
+# Coder — Software Engineer, AI Tools | READY TO SUBMIT
+
+**Status**: Ready for submission
+**Date prepared**: 2026-02-23
+**Posting source**: HN Who's Hiring, February 2026
+**Apply at**: https://coder.com/careers (exact posting URL not found via search — check the careers page directly or look for "Software Engineer, AI Tools" listing)
+
+---
+
+## Cover Letter
+
+Dear Coder hiring team,
+
+I built a hardened VM sandbox for autonomous coding agents because I needed to answer the same question Coder is answering at production scale: how do you let an agent execute arbitrary code without it escaping the sandbox, exfiltrating data, or corrupting the filesystem?
+
+The result is bilrost — a Lima VM with OverlayFS containment, Docker dual-container isolation, per-tool network policies via UFW, and gated filesystem sync that scans for secrets before anything leaves the sandbox. One command to provision: `bilrost up`. Published on PyPI. The threat model came first (STRIDE analysis with 7 documents and 5 proof-of-concept exploits), then the containment layers, then the developer experience. That sequence — security model, isolation primitives, simple interface — is exactly how I'd approach building agent-safe CDEs at Coder.
+
+The sandbox is one layer. The full stack I've built maps directly to what the AI Tools team needs:
+
+- **Agent runtime**: Vindler (openclaw) — production agent lifecycle management, 90 merged PRs. Start, dispatch tools, observe, terminate.
+- **Observability**: qortex-observe — full OpenTelemetry pipeline (Grafana, Jaeger, Prometheus) tracing every agent action from invocation through execution through feedback. You can't safely host what you can't observe.
+- **Integration surfaces**: An MCP server bridging Python and TypeScript over stdio transport (29 tool calls in 3.94s), plus 7 framework adapters (CrewAI, LangChain, Agno, AutoGen, Mastra, Smolagents, LangChain.js) — each implementing the framework's native interface so users swap one import. Coder's AI Tools team faces the same integration challenge: make CDEs work for every agent runtime without forcing each one to build a Coder-specific integration.
+
+I should be direct about Go: TypeScript and Python are my primary languages, and I'm actively picking up Rust. Go is on the learning path, and it's syntactically simpler than the Rust I'm writing now. The concurrency model — goroutines and channels — maps to the async agent patterns I've already built. I'd expect to be writing production Go within weeks. The harder ramp is Coder's architecture and codebase, not the language.
+
+The open-source angle matters to me. Both qortex and bilrost are published on PyPI. I run CI against the latest upstream framework versions with a zero-skip policy — if a dependency ships a breaking change on Monday, our build fails on Monday. I write mkdocs documentation sites, not just READMEs. Working on a project with 100k+ GitHub stars means that engineering discipline has real consequences for real users. That's the accountability I want.
+
+Peleke Sengstacke
+
+---
+
+## Application Form Notes
+
+**Likely required fields:**
+- Full name: Peleke Sengstacke
+- Email: (use primary email)
+- Location: Syracuse, NY (temporarily) / Atlanta, GA (home base) — fully remote, happy to travel for team events
+- Resume/CV: Upload current resume (emphasize bilrost, framework adapters, MCP server, qortex-observe, Vindler)
+- Portfolio/Website: https://peleke.dev
+- GitHub: https://github.com/Peleke
+- LinkedIn: (include if on profile)
+- Cover letter: Paste the cover letter above
+- How did you hear about this role: Hacker News Who's Hiring (February 2026)
+- Visa/work authorization: US citizen / authorized to work in the US (confirm as applicable)
+- Free-text / "Why Coder?": Lead with the bilrost/sandbox parallel. The containment problem is the same problem — Coder solves it at scale for thousands of developers and their coding agents simultaneously.
+
+**If there is a "What interests you about this role?" field:**
+Coder is defining how AI agents operate inside development environments, and that's the exact problem I've been solving at smaller scale. bilrost exists because autonomous agents need containment before they need capabilities. The open-source culture (100k+ stars) and the focus on agent-safe CDEs are the intersection of what I've built and what I want to build next.
+
+---
+
+## Key Links to Include
+
+| Link | Context |
+|------|---------|
+| https://peleke.dev | Portfolio — case studies, writing, lab projects |
+| https://github.com/Peleke | GitHub — open-source projects |
+| https://pypi.org/project/qortex/ | qortex on PyPI — retrieval engine with framework adapters |
+| https://pypi.org/project/bilrost/ | bilrost on PyPI — hardened VM sandbox for agent containment |
+
+---
+
+## Interview Prep Quick Sheet
+
+### 5 Most Likely Questions and Answers
+
+**1. "Walk us through how you'd design a sandboxed environment for an autonomous coding agent."**
+
+Start with the threat model. I used STRIDE for bilrost: what can the agent exfiltrate (network), corrupt (filesystem), exhaust (resources), or escalate (permissions)? Then build layered containment for each. Lima VM provides the outer process boundary. OverlayFS prevents persistent writes unless explicitly synced. UFW gives each tool its own network policy — the agent can hit the LLM API but not arbitrary endpoints. Gated sync means code changes don't leave the sandbox until a human or a policy approves them. For Coder's CDEs, the same layered approach applies at a different scale: the question is which isolation primitive — container, microVM, namespace — gives the right security/performance tradeoff for concurrent coding agents.
+
+**2. "How do you think about supporting multiple AI agent frameworks without building N custom integrations?"**
+
+Don't make them learn your API. Implement their interface. qortex ships adapters for 7 agent frameworks, and the design principle is: one import swap. If you're using CrewAI, you import qortex's CrewAI tool instead of CrewAI's default retrieval, and everything else works — same method signatures, same return types, same error handling. We pass CrewAI's own test suite, not ours. For Coder, the same principle applies: a CDE for autonomous agents should expose the interfaces agents already expect (filesystem, terminal, MCP), not force each agent framework to build a Coder-specific integration.
+
+**3. "You don't know Go. How would you ramp up?"**
+
+I switch between Python and TypeScript daily and I'm actively learning Rust. Go is syntactically simpler with a more constrained type system. The concurrency model — goroutines and channels — maps directly to the async agent patterns I've already built in Python (asyncio) and TypeScript. I'd expect to be writing production Go within the first few weeks. The bigger ramp is understanding Coder's codebase, architecture decisions, and deployment patterns — not the language syntax.
+
+**4. "What does monitoring autonomous agents look like?"**
+
+Every agent action becomes an OTel span with structured attributes: what tool was called, what arguments were passed, what the result was, how long it took, whether it succeeded. Grafana shows aggregates — P50/P99 latency, tool call success rates, agent session duration. Jaeger shows individual traces — you can follow one agent session from start to finish and see every decision it made. For Coder, when an autonomous coding agent is running in a CDE, the developer and the platform both need to know what it's doing, whether it's stuck, and whether it's doing something dangerous. That requires instrumentation at the CDE layer, not just the agent layer.
+
+**5. "Tell us about your open-source engineering practices."**
+
+CI runs against latest upstream framework versions with a zero-skip policy. If CrewAI ships a breaking change on Monday, our CI fails on Monday — not when a user reports it three weeks later. Both qortex and bilrost are published on PyPI with proper packaging. Documentation lives on GitHub Pages via mkdocs. The principle: treat your own tools with the same rigor you'd expect from the tools you depend on. I've maintained 7 framework adapters against upstream breaking changes, which taught me what real open-source maintenance demands — you don't just ship, you keep shipping.
+
+### 30-Second "Tell Me About Yourself" (Tailored to Coder)
+
+"I build infrastructure that makes autonomous agents safe to run in development environments. My main project is a hardened VM sandbox called bilrost — Lima VM, per-tool network isolation, gated filesystem sync — because agents need containment before they need capabilities. Around that, I've built an agent runtime, a full OTel observability pipeline, an MCP server, and adapters for 7 agent frameworks. Everything is published on PyPI with CI that breaks the same day a dependency ships a breaking change. Coder is solving the same containment and integration problem I've been solving, but at the scale of thousands of developers and their coding agents. That's the scale I want to work at."
+
+### One Question to Ask Them
+
+"Coder's CDEs are now hosting autonomous coding agents alongside human developers. How does the team think about the isolation boundary between an agent's actions and the rest of the development environment — is the agent a peer to the developer inside the CDE, or does it get its own sandboxed context within the environment?"
+
+---
+
+## Location Note
+
+Remote role. Currently in Syracuse, NY (temporary); home base is Atlanta, GA. Fully available for US/Canada time zones. Happy to travel for team events, offsites, and onboarding.

--- a/skills/custom/job-search/applications/coder-ai-tools.md
+++ b/skills/custom/job-search/applications/coder-ai-tools.md
@@ -1,0 +1,74 @@
+# Coder — Software Engineer, AI Tools
+
+## Role Summary
+- **Link**: https://coder.com/careers (HN Who's Hiring, February 2026)
+- **Location**: Remote (US/Canada/UK/Ireland/Poland)
+- **Comp**: Not listed (competitive — 100k+ GitHub star project, well-funded)
+- **Fit Score**: 5/5
+
+## Lead Profile
+Lead with **Developer Tools / Infrastructure** hybrid. Coder's product is cloud development environments, and the AI Tools role is about making those CDEs work for autonomous coding agents — sandboxed execution, monitoring, integration surfaces. The candidate's bilrost (sandboxed execution for agents), Vindler (agent runtime), and qortex-observe (monitoring) map directly. The open-source angle reinforces the DevTools profile: Coder has 100k+ GitHub stars, and the candidate publishes on PyPI, runs CI conformance testing across 7 frameworks, and builds documentation sites. This is someone who thinks about developer experience as a first-class concern.
+
+## Tailored Pitch (2-3 sentences)
+I build the infrastructure that makes autonomous agents safe to run in development environments: a hardened VM sandbox (bilrost) with per-tool network isolation and gated filesystem sync, a production agent runtime (Vindler), and OTel instrumentation tracing every agent action. The MCP server and 7 framework adapters mean I've already solved the integration problem Coder's AI Tools team faces — how do you build a platform that works across diverse agent runtimes without forcing each one to learn a new API? I ship open-source tooling with CI conformance testing and PyPI distribution, which matches the rigor a 100k-star project demands.
+
+## Resume Emphasis
+1. **bilrost** — Hardened VM sandbox for agent containment. Lima VM, OverlayFS, per-tool network isolation, gated sync. Single CLI command provisioning. Published on PyPI. This is Coder's CDE problem in miniature: safely isolating autonomous code execution with controlled access to external resources.
+2. **Framework adapters** — 7 frameworks (CrewAI, LangChain, Agno, AutoGen, Mastra, Smolagents, LangChain.js), all passing framework-authored test suites. 100+ CI tests with zero-skip policy and latest-version pinning. Demonstrates the platform integration discipline Coder needs for supporting diverse AI agents.
+3. **MCP server** — Cross-language stdio transport, Python-TypeScript bridge, 29 tool calls in 3.94s. MCP is the protocol autonomous coding agents use to connect to external services. Direct experience building the transport layer.
+4. **qortex-observe** — Full OTel pipeline (Grafana, Jaeger, Prometheus). Traces from invocation through execution through feedback. Monitoring autonomous agents is a core Coder requirement — you can't host what you can't observe.
+5. **Vindler (openclaw)** — Production agent runtime, 90 merged PRs. The agent lifecycle layer: start, run, dispatch tools, terminate. Maps to Coder's agent hosting infrastructure.
+6. **Open-source practice** — PyPI publishing (qortex, bilrost), mkdocs documentation sites, CI that installs latest framework versions and breaks immediately on upstream changes. Evidence of open-source engineering standards matching a 100k-star project.
+
+## Proof Point Mapping
+| Requirement | Evidence | Strength |
+|-------------|----------|----------|
+| Cloud Development Environments / sandboxed execution | bilrost: Lima VM + OverlayFS + Docker dual-container isolation + gated sync. Per-tool network policies. STRIDE threat model. Single-command provisioning. Published on PyPI. | strong |
+| AI agent infrastructure | Vindler (agent runtime), MCP server (agent communication), framework adapters (agent integration). Three layers of agent infrastructure covering runtime, transport, and ecosystem compatibility. | strong |
+| Monitoring autonomous agents | qortex-observe: OTel spans on every agent action. Grafana dashboards for latency and feedback rates. Jaeger for per-invocation traces. Posterior drift monitoring. | strong |
+| TypeScript | Strong TypeScript. LangChain.js adapter, Mastra adapter, MCP stdio transport — all TypeScript. Daily cross-language development. | strong |
+| Python | Primary language across all projects. qortex, bilrost, Vindler, framework adapters all Python. Published packages on PyPI. | strong |
+| Go | No production Go experience. Actively learning Rust (planning Rust runtime). Go is the natural next systems language — simpler syntax, goroutine model maps to async agent workloads. | gap |
+| Open-source engineering | PyPI packages, mkdocs documentation sites, CI with latest-version pinning and zero-skip policy. 7 adapters passing upstream test suites. 100+ CI tests. | strong |
+| Integration surfaces / protocol design | MCP server: 29 tool calls in 3.94s over stdio. Framework adapters: implement native interface so users swap one import. Design principle: don't make users learn a new API. | strong |
+
+## Why This Role (authentic)
+Coder is defining how AI agents operate inside development environments, and that's the exact problem I've been solving at smaller scale. bilrost exists because I asked "how do you let an autonomous agent execute code without it escaping the sandbox, exfiltrating data, or corrupting the filesystem?" Coder is asking the same question for thousands of developers and their coding agents simultaneously. The open-source angle matters to me — I publish on PyPI, I write documentation sites, I run CI that breaks when upstream frameworks ship changes. Working on a project with 100k+ GitHub stars means that engineering discipline has real consequences: a broken adapter doesn't just fail my tests, it fails someone's production workflow. That accountability is what I want.
+
+## Gap Analysis
+| Gap | How to Frame |
+|-----|-------------|
+| No Go experience (Coder's primary backend language) | Strong Python and TypeScript, actively learning Rust. Go is syntactically simpler than Rust and the concurrency model (goroutines/channels) maps to the async agent patterns I've already built. The ramp to production Go is weeks, not months. |
+| No experience on a large open-source project with external contributors | Published two PyPI packages, run CI conformance testing, write documentation sites. The engineering practices are there — the gap is operating at 100k-star scale with external PRs, issue triage, and release management. That's the experience I'd gain. |
+| No production multi-tenant CDE experience | bilrost is single-tenant by design (one VM per agent). The containment patterns transfer to multi-tenant isolation, but the operational complexity of hosting thousands of concurrent CDEs is new territory. Frame as: I bring the security model, Coder brings the scale. |
+| No enterprise cloud infrastructure (AWS/GCP/Azure) in the portfolio | All infrastructure is local-first (Lima VM, Docker). The abstractions transfer, but I haven't operated cloud infrastructure at enterprise scale. The trajectory from bilrost's local VM to cloud-hosted CDEs is architecturally natural. |
+
+## If They Ask X, Say Y
+- **"Walk us through how you'd design a sandboxed environment for an autonomous coding agent."** -- Start with the threat model. I used STRIDE for bilrost: what can the agent exfiltrate (network), what can it corrupt (filesystem), what can it exhaust (resources), what can it escalate (permissions)? Then build walls for each. Lima VM provides the outer process boundary. OverlayFS prevents persistent filesystem writes unless explicitly synced. UFW rules give each tool its own network policy — the agent can hit the LLM API but not arbitrary endpoints. Gated sync means code changes don't leave the sandbox until a human or a policy approves them. For Coder's CDEs, the same layered approach applies at a different scale: the question is which isolation primitive (container, microVM, namespace) gives the right security/performance tradeoff for concurrent coding agents.
+
+- **"How do you think about supporting multiple AI agent frameworks?"** -- Don't make them learn your API. Implement their interface. qortex ships adapters for 7 agent frameworks, and the design principle is: one import swap. If you're using CrewAI, you import qortex's CrewAI tool instead of CrewAI's default retrieval, and everything else works — same method signatures, same return types, same error handling. We pass CrewAI's own test suite, not ours. For Coder, the same principle applies: a CDE for autonomous agents should expose the interfaces agents already expect (filesystem, terminal, MCP), not force each agent framework to build a Coder-specific integration.
+
+- **"Tell us about your open-source engineering practices."** -- CI runs against latest upstream framework versions with zero-skip policy. If CrewAI ships a breaking change on Monday, our CI fails on Monday — not when a user reports it three weeks later. Both qortex and bilrost are published on PyPI with proper packaging. Documentation sites on GitHub Pages via mkdocs. The principle: treat your own tools with the same rigor you'd expect from tools you depend on.
+
+- **"You don't know Go. How would you ramp up?"** -- I switch between Python and TypeScript daily and I'm actively learning Rust. Go is syntactically simpler than Rust with a more constrained type system. The concurrency model — goroutines and channels — maps directly to the async agent workload patterns I've already built. I'd expect to be writing production Go within the first few weeks. The harder ramp is Coder's codebase and architecture decisions, not the language.
+
+- **"What does monitoring autonomous agents look like?"** -- Every agent action becomes an OTel span with structured attributes: what tool was called, what arguments were passed, what the result was, how long it took, whether the agent considered it successful. Grafana shows aggregates — P50/P99 latency, tool call success rates, agent session duration. Jaeger shows individual traces — you can follow one agent session from start to finish and see every decision it made. For Coder, the monitoring question is: when an autonomous coding agent is running in a CDE, the developer (or the platform) needs to know what it's doing, whether it's stuck, and whether it's doing something dangerous. That requires instrumentation at the CDE layer, not just the agent layer.
+
+- **"How do you think about developer experience for platform tools?"** -- The bar is: a developer should be able to start using the tool without reading documentation. bilrost is `bilrost up` and you have a sandbox. The MCP server is one config block and you have 29 tools. Framework adapters are one import swap. If the getting-started experience requires more than one step, the abstraction is wrong. For Coder's AI tools, the same principle applies: enabling an autonomous agent in a CDE should be a toggle, not a migration.
+
+- **"What interests you about Coder specifically?"** -- Two things. First, the problem is real and specific: autonomous coding agents need sandboxed environments with controlled resource access, and CDEs are the natural hosting primitive. Second, Coder is open-source at scale — 100k+ stars means engineering decisions have immediate consequences for real users. I want to work where the rigor matters.
+
+## Cover Letter Hooks
+- I built a hardened VM sandbox (bilrost) because autonomous agents need containment before they need capabilities — and Coder is solving the same problem at production scale for development environments hosting autonomous coding agents.
+- The integration surface is the hard part: my MCP server bridges Python and TypeScript over stdio transport (29 tool calls in 3.94s), and my 7 framework adapters each implement the framework's native interface so users swap one import. Coder's AI Tools team faces the same challenge — making CDEs work for every agent framework without forcing each one to build a custom integration.
+- I publish on PyPI, run CI against latest upstream versions with zero-skip policy, and break the build the same day a dependency ships a breaking change. That's the engineering discipline a 100k-star open-source project requires.
+- My agent infrastructure work covers the full stack Coder's AI Tools team needs: sandboxed execution (bilrost), agent runtime (Vindler), observability (qortex-observe), and cross-framework integration (MCP + 7 adapters).
+
+## Application Notes
+- Coder is open-source-first. Emphasize the open-source engineering practices: PyPI, CI conformance, documentation sites, upstream test suite compatibility.
+- The JD says "defining how AI agents operate in development workflows" — map this directly to the framework adapter and MCP experience. The candidate has already defined agent integration surfaces.
+- Go is the primary gap. Address it proactively in the application, not defensively. The trajectory (Python -> TypeScript -> Rust -> Go) is natural for someone moving toward systems languages.
+- Emphasize REMOTE availability — no relocation friction, available across US/Canada time zones.
+- Coder's 100k+ GitHub stars is a signal they care about community and ecosystem. Mention PyPI downloads, documentation quality, and CI practices — not just features.
+- If there's a free-text field, lead with the bilrost/sandbox story. Coder's core product is environments, and bilrost is an environment purpose-built for agent containment. The parallel is the strongest hook.
+- The MCP angle is timely — MCP is becoming the standard protocol for agent-tool communication, and the candidate has production MCP experience. Call this out explicitly.

--- a/skills/custom/job-search/applications/databricks-ml-systems.md
+++ b/skills/custom/job-search/applications/databricks-ml-systems.md
@@ -1,0 +1,70 @@
+# Databricks — Senior Applied AI Engineer, ML for Systems & Infrastructure
+
+## Role Summary
+- **Link**: https://www.databricks.com/company/careers/engineering---pipeline/senior-applied-ai-engineer--ml-for-systems--infrastructure-7859597002
+- **Location**: Mountain View, CA
+- **Comp**: Not listed
+- **Fit Score**: 5/5
+
+## Lead Profile
+**ML / AI Engineer.** This role explicitly asks for applying ML scheduling and optimization algorithms to improve engineering systems. That is a literal description of what qortex does: Thompson Sampling (an optimization algorithm from the bandit literature) applied to retrieval infrastructure to make it self-improving. The ML Engineer profile foregrounds the algorithm work and the measured retrieval quality gains.
+
+## Tailored Pitch (2-3 sentences)
+I apply optimization algorithms from the bandit literature to make retrieval infrastructure learn from usage. qortex composes Thompson Sampling with Personalized PageRank over typed knowledge graph edges, producing +22% precision and +26% recall vs vanilla cosine — with 0.02ms median graph explore overhead. This is applied ML research that ships as production infrastructure: 7 framework adapters, 100+ CI tests, PyPI distribution.
+
+## Resume Emphasis
+1. **qortex — Thompson Sampling as systems optimization.** The role says "applying ML scheduling and optimization algorithms to improve engineering systems." Thompson Sampling on edge weights IS an optimization algorithm applied to retrieval infrastructure. Beta-Bernoulli posteriors update from usage feedback — no retraining, no LLM calls.
+2. **Retrieval quality benchmarks.** +22% precision, +26% recall, +14% nDCG vs vanilla cosine on a controlled 20-concept domain with distractors. This is the evidence that the optimization algorithm works.
+3. **Production performance at scale.** Graph explore adds 0.02ms median overhead. Feedback recording at <0.01ms. Embedding is 99.5% of cost. The optimization layer is effectively free.
+4. **Framework adapters as deployment strategy.** 7 framework adapters (CrewAI, LangChain, Agno, AutoGen, Mastra, Smolagents, LangChain.js) — all passing framework-authored test suites. This is how you deploy ML infrastructure into diverse production environments.
+5. **MCP transport — cross-language production bridge.** 29 tool calls in 3.94s over stdio. Python engine serving TypeScript ecosystems. Infrastructure that works across language boundaries.
+6. **bilrost — production containment infrastructure.** Single-command VM provisioning with STRIDE threat modeling. Tier 0 environments need containment guarantees for agent systems.
+
+## Proof Point Mapping
+| Requirement | Evidence | Strength |
+|-------------|----------|----------|
+| Applying ML optimization algorithms to improve engineering systems | Thompson Sampling on knowledge graph edge weights; Beta-Bernoulli posteriors that update from usage feedback — the algorithm optimizes retrieval paths in real time | Direct match |
+| Strong coding / SWE fundamentals | 7 framework adapters with 100+ CI tests, PyPI-published packages (qortex, bilrost), zero-skip CI policy with latest-version pinning | Strong |
+| Deploying and scaling models in production | MCP server (29 calls/3.94s), framework adapters passing production test suites, graph explore at 0.02ms median overhead | Strong |
+| Monitoring models in production | qortex-observe: full OTel instrumentation (Grafana, Jaeger, Prometheus), traces from query through retrieval to feedback, posterior drift dashboards | Strong |
+| Infrastructure challenges in Tier 0 environments | bilrost VM sandbox with STRIDE threat model, network isolation, profile-based containment for agent workloads | Moderate — containment focus, not Databricks-scale distributed systems |
+| ML scheduling algorithms | Thompson Sampling IS a scheduling algorithm — it allocates exploration vs exploitation across retrieval paths based on posterior uncertainty. Same math as contextual bandits used in job scheduling | Direct match |
+| Cross-functional collaboration | Framework adapters require implementing 7 different API contracts designed by 7 different teams. edX experience in education platform engineering | Moderate |
+
+## Why This Role (authentic)
+Databricks is where data infrastructure meets ML, and this role sits at the intersection I've been building toward: applying ML algorithms to make systems better, not just using systems to serve ML. The specific language — "ML scheduling and optimization algorithms to improve engineering systems" — describes what I built with qortex before I saw this posting. Thompson Sampling is a scheduling algorithm. Applying it to retrieval edge weights to make infrastructure self-improving is the same class of problem as optimizing Spark job scheduling or resource allocation. I want to do this work at Databricks scale, on infrastructure that millions of data teams depend on.
+
+## Gap Analysis
+| Gap | How to Frame |
+|-----|-------------|
+| No distributed systems at Databricks scale (Spark, Delta Lake) | The optimization algorithm work transfers directly. Thompson Sampling on retrieval edges and Thompson Sampling on cluster scheduling are the same math at different scales. I learn infrastructure fast — went from zero to PyPI-published VM provisioning tool in weeks. |
+| No explicit Spark / data engineering background | Frame as a strength: fresh perspective on applying modern ML optimization to data infrastructure. The role asks for ML engineers, not Spark engineers. |
+| Single-developer projects, not large team experience | edX was a large engineering org. Framework adapters require conformance to 7 external teams' API contracts — that's cross-team collaboration by design. |
+| Mountain View location (relocation may be needed) | Address directly if asked. Willing to relocate for the right role. Databricks' Mountain View campus is the right role. |
+
+## If They Ask X, Say Y
+1. **"How does Thompson Sampling apply to systems infrastructure?"** → Thompson Sampling solves the explore-exploit tradeoff. In retrieval, it decides which knowledge graph paths to prioritize based on posterior uncertainty. In systems infrastructure, the same algorithm decides which scheduling policies, resource allocations, or routing strategies to explore vs exploit. I've implemented it end-to-end: Beta-Bernoulli posteriors, feedback recording at <0.01ms, convergence analysis over 30 days.
+
+2. **"What's your experience with production ML systems?"** → qortex runs a full production loop: query comes in, three-signal retrieval executes (vector + PPR + Thompson Sampling), results go to the agent, feedback updates posteriors. qortex-observe instruments this entire pipeline with OTel — Grafana dashboards track retrieval latency, feedback rates, and posterior drift. The MCP server handles 29 tool calls in 3.94s over real stdio transport.
+
+3. **"Tell me about a time you improved system performance with ML."** → Vanilla cosine similarity was our baseline retrieval. I added two layers: Personalized PageRank over typed edges for structural context, then Thompson Sampling on edge weights for adaptive learning. Controlled benchmark on a 20-concept domain: +22% precision, +26% recall, +14% nDCG. The graph explore layer adds 0.02ms median — embedding remains 99.5% of cost. The ML optimization is effectively free in latency terms.
+
+4. **"How do you evaluate your work?"** → Controlled benchmarks with distractors. Precision@k, Recall@k, nDCG@k on a domain where I know ground truth. Overhead benchmarks with median and percentile reporting. Convergence analysis on posterior divergence over time. Framework test suite conformance — not my tests, theirs. I measure before I claim.
+
+5. **"What draws you to Databricks specifically?"** → The job description says "applying ML scheduling and optimization algorithms to improve engineering systems." I built that exact thing before I saw this posting. Thompson Sampling on retrieval edge weights is an optimization algorithm applied to engineering infrastructure. Doing this at Databricks scale — where the systems serve millions of data teams — is the version of this work that matters most.
+
+6. **"How do you handle the transition from single-developer to large-team infrastructure?"** → My framework adapters are built to conform to external API contracts — 7 different frameworks, each with their own interface expectations and test suites. That's the same muscle as working within a large codebase with established conventions. I also have edX experience, which was a large engineering organization with production education infrastructure.
+
+## Cover Letter Hooks
+1. "The role description says 'applying ML scheduling and optimization algorithms to improve engineering systems.' I've been doing exactly that — Thompson Sampling on knowledge graph edge weights produces +22% precision over vanilla cosine, at 0.02ms median overhead. The algorithm is well-studied; applying it to make retrieval infrastructure self-improving is the work I want to bring to Databricks scale."
+
+2. "Most retrieval systems are static — you embed, you search, you hope. I built one that learns. qortex applies Beta-Bernoulli posteriors to knowledge graph edges so the system discovers which retrieval paths matter from usage feedback, not retraining. This is applied ML research that ships as infrastructure, and Databricks is where infrastructure meets ML."
+
+3. "I apply bandit algorithms to systems problems. Thompson Sampling decides which knowledge graph paths to explore vs exploit. The same optimization framework applies to cluster scheduling, resource allocation, and query routing — the core infrastructure challenges this role targets at Databricks."
+
+## Application Notes
+- Mountain View location — confirm relocation willingness early.
+- Databricks is a Tier 1 target company listed in the ML Engineer profile.
+- The "ML for Systems" framing is the strongest possible angle — lead every conversation with Thompson Sampling as optimization, not as "AI/ML."
+- Databricks likely uses similar bandit/optimization approaches internally for Spark scheduling and resource management. Research their published papers on ML-driven infrastructure optimization before interviewing.
+- Salary not listed — Databricks senior engineer comp is typically $250K-$400K+ total (base + equity). Research current levels on levels.fyi.

--- a/skills/custom/job-search/applications/grafana-genai-eval-READY.md
+++ b/skills/custom/job-search/applications/grafana-genai-eval-READY.md
@@ -1,0 +1,129 @@
+# Grafana Labs — Senior SE, GenAI & ML Evaluation Frameworks
+## READY-TO-SUBMIT APPLICATION PACKAGE
+
+**Posting**: https://job-boards.greenhouse.io/grafanalabs/jobs/5559973004
+**Status**: READY TO SUBMIT
+**Comp range**: $148,505 - $178,206 (base) + RSUs + benefits
+**Location**: Remote, USA
+
+---
+
+## Cover Letter
+
+Dear Grafana Labs Hiring Team,
+
+I run Grafana, Jaeger, and Prometheus in production to observe AI retrieval systems. qortex-observe instruments the full pipeline with OpenTelemetry -- traces from query through graph explore to feedback, dashboards tracking posterior drift over 30 days. When I saw this role, I recognized the job description as a summary of what I've already built on your stack.
+
+My retrieval system composes vector similarity, Personalized PageRank, and Thompson Sampling into a three-signal retrieval layer. I evaluate it with P@5, R@5, and nDCG@5 on a controlled 20-concept domain with distractors -- not just positive examples, because without distractors every retrieval system looks good. Results: +22% precision, +26% recall, +14% nDCG versus vanilla cosine similarity. These numbers come from golden test sets with known ground truth, the same evaluation methodology this role asks you to build as a platform capability.
+
+On the CI/CD side, I maintain 100+ tests across 7 framework adapters (CrewAI, LangChain, Agno, AutoGen, Mastra, Smolagents, LangChain.js) with a zero-skip policy and latest-version framework pinning. If CrewAI ships a breaking change on Tuesday, CI fails on Tuesday. This is evaluation-in-CI at the speed frameworks ship -- exactly the regression tracking pipeline this role requires.
+
+For structured output evaluation, I use Thompson Sampling with Beta-Bernoulli posteriors on knowledge graph edge weights, tracking convergence over 30 days of production data. This is a principled complement to LLM-as-judge methods: statistical evaluation where you can get closed-form answers, LLM-as-judge where you need open-ended assessment, and inter-rater reliability metrics to calibrate both.
+
+Grafana Labs built the observability platform I chose independently. This role is the intersection of AI evaluation expertise and the Grafana stack -- and I'm already standing at that intersection. I'd welcome the opportunity to build GenAI evaluation frameworks on the platform where my data already lives.
+
+Peleke Sengstacke
+
+---
+
+## Application Form Notes
+
+Greenhouse standard application fields for this posting:
+
+| Field | What to Enter |
+|-------|---------------|
+| **First Name** | Peleke |
+| **Last Name** | Sengstacke |
+| **Email** | (personal email) |
+| **Phone** | (personal phone) |
+| **Resume** | Upload current resume PDF |
+| **Cover Letter** | Paste the cover letter above (or upload as PDF) |
+| **LinkedIn** | LinkedIn profile URL (ensure profile is current and public) |
+| **Website / Portfolio** | https://peleke.dev |
+| **GitHub** | https://github.com/Peleke |
+| **How did you hear about us?** | "Job board / Greenhouse careers page. I also use Grafana, Jaeger, and Prometheus in my own AI observability stack (qortex-observe), so I actively follow Grafana Labs' product direction." |
+| **Location** | Syracuse, NY (remote -- willing to travel for team offsites) |
+| **Are you authorized to work in the US?** | Yes |
+| **Do you now or will you require sponsorship?** | No |
+| **Anything else?** | "I built qortex-observe on the Grafana/Jaeger/Prometheus stack for AI retrieval observability. Portfolio with technical writeups: https://peleke.dev" |
+
+**Before submitting, verify:**
+- [ ] Resume is updated with qortex-observe, retrieval benchmarks, and framework adapter CI details
+- [ ] LinkedIn profile is public and matches resume
+- [ ] Portfolio site (peleke.dev) is live and loading correctly
+- [ ] Cover letter is pasted (not just uploaded) if Greenhouse provides a text field
+
+---
+
+## Key Links to Include
+
+| Link | URL | Where to Use |
+|------|-----|-------------|
+| Portfolio | https://peleke.dev | Website/Portfolio field, cover letter |
+| GitHub | https://github.com/Peleke | GitHub field |
+| LinkedIn | (your LinkedIn URL) | LinkedIn field |
+| Greenhouse Posting | https://job-boards.greenhouse.io/grafanalabs/jobs/5559973004 | Reference only |
+
+**Note on qortex repo visibility**: If the qortex repo or qortex-observe repo is public, include the direct GitHub link in the "Anything else" field. If private, the portfolio writeups at peleke.dev serve as the public proof layer.
+
+**Note on published articles**: If the feedback loop / convergence analysis article is live on peleke.dev, include the direct URL. This is the single strongest artifact for this role -- it demonstrates golden test set design, regression tracking, and the Grafana observability angle all in one piece.
+
+---
+
+## Interview Prep Quick Sheet
+
+### The 30-Second Pitch (for "Tell me about yourself")
+
+> I'm a software engineer focused on AI retrieval evaluation and observability. I built qortex, a knowledge graph retrieval system that composes vector similarity, Personalized PageRank, and Thompson Sampling -- and I evaluate it with P@k and nDCG on controlled domains, not vibes. The observability layer runs on Grafana, Jaeger, and Prometheus with full OTel instrumentation. I maintain 100+ CI tests across 7 framework adapters with a zero-skip policy. This role asks me to build GenAI evaluation frameworks on the observability platform I already use daily -- that's why I'm here.
+
+### 5 Most Likely Questions
+
+**1. "Describe your experience with Grafana and observability."**
+
+qortex-observe is a full OTel instrumentation layer for AI retrieval. Grafana for dashboards -- retrieval latency, feedback rates, posterior drift. Jaeger for distributed traces -- query to retrieval to graph explore to feedback. Prometheus for metrics collection. This is how I monitor whether Thompson Sampling actually improves retrieval quality over time. I chose the Grafana stack because it's the best open-source observability platform. Now I want to help build it.
+
+**2. "How would you design an evaluation framework for GenAI systems?"**
+
+Start with the evaluation taxonomy. Retrieval quality (P@k, nDCG) is different from response quality (LLM-as-judge) is different from system performance (latency, throughput). Each needs its own golden test set design, regression thresholds, and CI integration strategy. The pipeline: define golden set with distractors, instrument the system with OTel, run evaluation suite in CI, push metrics to Prometheus, visualize in Grafana, alert on regressions. The framework should make that pipeline a one-import setup for internal teams.
+
+**3. "How do you approach golden test set design?"**
+
+Controlled domains with known ground truth. My retrieval benchmark uses a 20-concept authorization domain with distractors -- concepts that are semantically similar but not relevant. I measure P@5, R@5, and nDCG@5, which catches both precision failures (wrong results) and ranking failures (right results in wrong order). Key insight: golden sets need distractors, not just positive examples. Without distractors, every retrieval system looks good.
+
+**4. "What's your experience with CI/CD integration of evaluation?"**
+
+100+ CI tests across 7 framework adapters. Latest-version framework pinning -- not locked versions, latest. Zero-skip policy: if a test is flaky, fix it, don't skip it. If CrewAI ships a breaking change on Tuesday, CI fails on Tuesday. For GenAI evaluation in CI, same philosophy: run evaluations on every commit, fail the build if quality regresses below thresholds.
+
+**5. "LLM-as-judge -- what's your take?"**
+
+It solves a real problem: evaluating open-ended generation where P@k doesn't apply. But it has calibration issues -- different models judge differently, same model judges differently across prompts. I complement LLM-as-judge with statistical methods: inter-rater reliability metrics, confidence intervals, and closed-form evaluation where possible (P@k, nDCG). Thompson Sampling is relevant here -- you can model judge reliability as a bandit problem and weight scores by posterior confidence.
+
+### One Question to Ask Them
+
+> "The job description mentions golden test sets and regression tracking. How does the team currently manage dataset versioning and golden set evolution -- do evaluation datasets live alongside code in version control, or is there a separate data management layer? I'm curious because in my experience, test set drift is the silent killer of evaluation pipelines."
+
+This shows you've thought about the operational reality of evaluation at scale, not just the algorithms.
+
+### Bonus Questions to Have Ready
+
+- "What does the GenAI evaluation framework serve internally -- is it primarily for Grafana's own AI features (like AI-assisted dashboarding), or is it also a product offering for Grafana Cloud customers?"
+- "How does the team think about the relationship between trace-level observability and batch evaluation? In my experience they inform each other -- traces surface failure modes that become golden test cases."
+
+---
+
+## Location Note
+
+Currently in Syracuse, NY (temporary). Home base is Atlanta, GA. This is a remote role (USA/Canada) so location is not a concern. Willing to travel for team events, onboarding, and offsites as needed.
+
+---
+
+## Submission Checklist
+
+- [ ] Resume PDF uploaded
+- [ ] Cover letter pasted/uploaded
+- [ ] LinkedIn URL entered (profile set to public)
+- [ ] Portfolio URL entered: https://peleke.dev
+- [ ] GitHub URL entered: https://github.com/Peleke
+- [ ] "How did you hear about us" filled in
+- [ ] All required fields completed
+- [ ] Submit at https://job-boards.greenhouse.io/grafanalabs/jobs/5559973004

--- a/skills/custom/job-search/applications/grafana-genai-eval.md
+++ b/skills/custom/job-search/applications/grafana-genai-eval.md
@@ -1,0 +1,74 @@
+# Grafana Labs — Senior Software Engineer, GenAI & ML Evaluation Frameworks
+
+## Role Summary
+- **Link**: https://job-boards.greenhouse.io/grafanalabs/jobs/5559973004
+- **Location**: USA Remote or Canada Remote
+- **Comp**: $154,445 - $185,334
+- **Fit Score**: 5/5
+
+## Lead Profile
+**ML / AI Engineer**, supplemented by **Developer Tools / DevEx.** This role sits at the intersection of AI evaluation and observability infrastructure. The ML profile provides the retrieval evaluation expertise (P@k, nDCG, golden test sets, regression tracking). The Dev Tools profile provides the CI/CD integration and framework packaging sensibility. The unique angle: the candidate already runs Grafana + Jaeger + Prometheus in production for AI system observability. This is the "we use your stack" story.
+
+## Tailored Pitch (2-3 sentences)
+I run Grafana, Jaeger, and Prometheus in production to observe AI retrieval systems — qortex-observe instruments the full pipeline from query through graph explore to feedback with OpenTelemetry. I evaluate retrieval quality with P@k, R@k, and nDCG@k on controlled domains, track posterior convergence over 30 days, and run 100+ CI tests across 7 framework adapters with a zero-skip policy. This role asks me to build evaluation frameworks for AI/ML systems on the observability platform I already use daily.
+
+## Resume Emphasis
+1. **qortex-observe — Grafana/Jaeger/Prometheus in production.** Full OTel instrumentation for AI retrieval. Traces span from query to retrieval to graph explore to feedback. Dashboards track retrieval latency, feedback rates, and posterior drift. This is not theoretical observability — it runs on their stack.
+2. **Retrieval evaluation methodology.** P@5, R@5, nDCG@5 on a controlled 20-concept domain with distractors. Golden test set design. Before/after regression tracking (+22% precision, +26% recall, +14% nDCG). This maps directly to "golden test sets, regression tracking" in the job description.
+3. **CI/CD integration of evaluation pipelines.** 100+ CI tests across 7 framework adapters. Zero-skip policy. Latest-version framework pinning — if a framework ships a breaking change, CI catches it the same day. This is evaluation-in-CI, which the role explicitly requires.
+4. **Thompson Sampling convergence analysis.** 30 days of posterior divergence data. Convergence plots. Interactive Beta distribution widget. This is structured output evaluation and regression tracking for ML systems — the learning component of evaluation.
+5. **Framework adapters as evaluation surface.** 7 adapters (CrewAI, LangChain, Agno, AutoGen, Mastra, Smolagents, LangChain.js) each passing framework-authored tests. Each adapter is an evaluation boundary: does the integration still conform after framework updates?
+6. **Open-source distribution.** PyPI packages, mkdocs docs, CI/CD pipelines. Grafana Labs is an open-source company. The candidate ships like one.
+
+## Proof Point Mapping
+| Requirement | Evidence | Strength |
+|-------------|----------|----------|
+| Evaluation frameworks for AI/ML systems | Controlled retrieval benchmark suite: P@5, R@5, nDCG@5 on 20-concept domain with distractors. Overhead benchmarks with percentile reporting. Convergence analysis over 30 days. | Direct match |
+| Prompt engineering and structured output evaluation | Three-signal retrieval composition (vector + PPR + Thompson Sampling) with structured evaluation at each stage. Interactive Beta distribution widget for visualizing posterior outputs. | Strong |
+| Context-window management | Knowledge graph retrieval is fundamentally a context-window optimization problem — selecting the most relevant context for a given query. Thompson Sampling optimizes which context components to include. | Strong |
+| Golden test sets | 20-concept controlled domain with known ground truth and distractors. Framework-authored test suites as golden conformance tests. | Direct match |
+| Regression tracking | Before/after benchmarks: +22% precision, +26% recall, +14% nDCG. CI with latest-version pinning catches regressions same-day. Zero-skip policy. | Direct match |
+| LLM-as-judge methods | Thompson Sampling on feedback is a principled alternative to LLM-as-judge — it uses Beta-Bernoulli posteriors instead of LLM scoring. Can articulate tradeoffs between both approaches. | Moderate — different approach to same problem |
+| CI/CD integration of evaluation pipelines | 100+ CI tests, 7 framework adapters, latest-version pinning, zero-skip policy. Evaluation runs on every commit. | Direct match |
+| Observability / Grafana experience | qortex-observe: Grafana + Jaeger + Prometheus with OTel instrumentation. Production dashboards tracking retrieval latency, feedback rates, posterior drift. Uses Grafana daily. | Direct match |
+
+## Why This Role (authentic)
+This is the role where every piece of my experience converges. I already run Grafana, Jaeger, and Prometheus to observe AI retrieval systems. I already evaluate retrieval quality with P@k and nDCG on controlled domains. I already integrate evaluation into CI/CD with 100+ tests and a zero-skip policy. The job description reads like a summary of what I built independently — evaluation frameworks, golden test sets, regression tracking, CI/CD integration — except Grafana Labs does it at scale, for the entire industry, on the observability platform I already use. And it's remote. Building GenAI evaluation frameworks on top of the Grafana stack, from home, is the exact role I'd design for myself.
+
+## Gap Analysis
+| Gap | How to Frame |
+|-----|-------------|
+| No Go experience (Grafana's primary language) | Python and TypeScript are the languages of the GenAI ecosystem this role serves. Go for internal tooling can be learned; deep GenAI evaluation expertise in Python/TS cannot be quickly acquired. Currently learning Rust, which demonstrates systems-language learning appetite. |
+| LLM-as-judge: different approach | Thompson Sampling on feedback is a principled alternative — Beta-Bernoulli posteriors instead of LLM scoring. Frame as complementary expertise: I bring the statistical evaluation perspective that makes LLM-as-judge results more rigorous. |
+| No Grafana plugin/extension development experience | I'm a power user, not yet a contributor. But I understand the data model (traces, metrics, logs) from the producer side. Building evaluation dashboards as a user informs building evaluation frameworks as a developer. |
+| Comp range ($154K-$185K) is lower than other targets | Remote USA/Canada is a significant quality-of-life benefit. Evaluate total comp including equity, benefits, and the remote premium. Grafana Labs is pre-IPO — equity could be significant. |
+
+## If They Ask X, Say Y
+1. **"Describe your experience with Grafana and observability."** → qortex-observe is a full OTel instrumentation layer for AI retrieval. I run Grafana for dashboards (retrieval latency, feedback rates, posterior drift), Jaeger for distributed traces (query to retrieval to graph explore to feedback), and Prometheus for metrics collection. This isn't a toy setup — it's how I monitor whether Thompson Sampling is actually improving retrieval quality over time. I chose the Grafana stack because it's the best open-source observability platform. Now I want to help build it.
+
+2. **"How would you design an evaluation framework for GenAI systems?"** → Start with the evaluation taxonomy. Retrieval quality (P@k, nDCG) is different from response quality (LLM-as-judge) is different from system performance (latency, throughput). Each needs its own golden test set design, its own regression thresholds, its own CI integration strategy. The framework should make it easy to define golden sets, run evaluations on every commit, track regressions over time, and surface results in Grafana dashboards. The pipeline: define golden set, instrument the system with OTel, run evaluation suite in CI, push metrics to Prometheus, visualize in Grafana, alert on regressions.
+
+3. **"How do you approach golden test set design?"** → Controlled domains with known ground truth. My retrieval benchmark uses a 20-concept authorization domain with distractors — concepts that are semantically similar but not relevant. I measure P@5, R@5, and nDCG@5, which catches both precision failures (wrong results) and ranking failures (right results in wrong order). The key insight: golden sets need distractors, not just positive examples. Without distractors, every retrieval system looks good.
+
+4. **"What's your experience with CI/CD integration of evaluation?"** → 100+ CI tests across 7 framework adapters. Latest-version framework pinning — not locked versions, latest. Zero-skip policy: if a test is flaky, we fix it, not skip it. If CrewAI ships a breaking change on Tuesday, our CI fails on Tuesday. This is how you catch regressions at the speed frameworks ship. For GenAI evaluation in CI, the same philosophy applies: run evaluations on every commit, fail the build if quality regresses.
+
+5. **"LLM-as-judge — what's your take?"** → It solves a real problem: evaluating open-ended generation where P@k doesn't apply. But it has calibration issues — different models judge differently, and the same model judges differently across prompts. I'd complement LLM-as-judge with statistical methods: inter-rater reliability metrics, confidence intervals, and where possible, closed-form evaluation like P@k and nDCG. Thompson Sampling is actually relevant here — you can model judge reliability as a bandit problem and weight judge scores by posterior confidence.
+
+6. **"Why Grafana Labs over other observability companies?"** → Open source. Grafana Labs built the observability stack I chose independently — Grafana, Prometheus, and the broader LGTM stack. The GenAI evaluation role is the perfect convergence: I bring AI evaluation expertise to the observability platform I already run. And the remote-first culture means I can focus on the work.
+
+7. **"Tell me about context-window management."** → Knowledge graph retrieval is fundamentally context-window optimization. Given a query, which chunks of context should fill the LLM's window? Thompson Sampling on edge weights learns which context components matter for which query patterns. PPR provides structural context (related concepts). Vector similarity provides semantic relevance. Composing these three signals produces a context window that's optimized for the query, not just semantically similar to it. This is measurable: +22% precision means 22% fewer irrelevant chunks in the context window.
+
+## Cover Letter Hooks
+1. "I run Grafana, Jaeger, and Prometheus in production to observe AI retrieval systems. qortex-observe instruments the full pipeline with OpenTelemetry — traces from query through graph explore to feedback, dashboards tracking posterior drift over 30 days. When I saw Grafana Labs hiring for GenAI evaluation frameworks, I recognized the job description as a summary of what I've already built on your stack."
+
+2. "Evaluation without observability is guesswork. Observability without evaluation is noise. This role combines both, and that's exactly what I do: P@k and nDCG on controlled domains for evaluation, Grafana and Jaeger for observability, CI with 100+ tests and zero-skip policy for regression tracking. Building this as a platform feature for the entire Grafana ecosystem is the work I want to do."
+
+3. "Most GenAI evaluation frameworks treat retrieval as a black box. I measure it at every stage: embedding latency, graph explore overhead (0.02ms median), context relevance (P@5), and learning convergence (30 days of posterior divergence). Bringing this evaluation methodology to Grafana Labs — the observability platform where my data already lives — is a natural next step."
+
+## Application Notes
+- Remote USA/Canada is a major advantage. No relocation required.
+- Comp range ($154K-$185K) is the lowest of the three targets. Research Grafana Labs total comp (equity, benefits) and pre-IPO trajectory.
+- Grafana Labs is an open-source company — open-source contributions are highly valued. Consider contributing to Grafana's AI/ML observability features before or during the application process.
+- The "we already use your stack" angle is the strongest differentiator. No other candidate will walk in with production Grafana + OTel instrumentation for AI retrieval systems.
+- Go is Grafana's primary backend language. If this role requires Go, flag the learning curve but emphasize Python/TypeScript as the languages of the GenAI ecosystem this role serves. Learning Rust already demonstrates systems-language appetite.
+- This role may overlap with Grafana's "AI Observability" product direction (Grafana Cloud traces for LLM applications). Research their recent announcements in this space.

--- a/skills/custom/job-search/applications/livekt-agent-platform-READY.md
+++ b/skills/custom/job-search/applications/livekt-agent-platform-READY.md
@@ -1,0 +1,136 @@
+# LiveKit — Senior Software Engineer, Agent Platform — READY TO SUBMIT
+
+## Job Posting Details
+
+- **Title**: Senior Software Engineer, Agent Platform (also listed as "Agents Hosting")
+- **Company**: LiveKit
+- **Apply URL**: https://jobs.ashbyhq.com/livekit/f152aa9f-981c-4661-99d3-6837654b9c8b
+- **Alt listing**: https://jobs.ashbyhq.com/livekit/1757f49e-7e19-4c45-85f7-e4637dff66fb (Senior Software Engineer, Agents)
+- **Location**: Remote (US)
+- **Comp**: $120,000 - $250,000
+- **Tech stack**: Go, Firecracker, Docker, Temporal
+
+### Responsibilities (from JD)
+- Develop the core platform for hosting agents
+- Build resilient systems to deploy agents across global data centers
+- Create end-to-end tooling for seamless management of hosted agents
+- Work with Go, Firecracker, Docker, Temporal, and similar technologies
+
+### Desired Traits (from JD)
+- Obsess with crafting code that is fast, reliable, and practical for the problem
+- Known as the go-to person for tackling tough technical problems
+- Work hard, build and ship fast
+- Clearly explain complex technical concepts to others
+- Fast learner who frequently picks up new languages and tools
+
+---
+
+## Cover Letter
+
+Dear LiveKit Hiring Team,
+
+I've been building an agent runtime, a hardened sandbox, and an observability layer independently — when I saw LiveKit's Agent Platform team, I realized you're productionizing the same architecture at scale.
+
+Over the past year I've shipped three layers of agent infrastructure from scratch. **bilrost** is a Lima VM sandbox for agent containment: per-tool network isolation via UFW firewall rules, OverlayFS to prevent persistent filesystem modification, gated sync so nothing leaves the sandbox without explicit approval, and Docker dual-container isolation — air-gapped by default, bridged only per-tool. The design started from a STRIDE threat model with seven analysis documents and five proof-of-concept exploits, because I needed to answer the same question LiveKit's platform answers at scale: how do you safely run autonomous code that makes its own tool calls? bilrost is published on PyPI and provisions with a single command.
+
+**Vindler** is the production agent runtime sitting inside that sandbox — lifecycle management, tool dispatch, and the production loop that coordinates agent execution. Ninety merged PRs, OpenTelemetry instrumentation on every action. **qortex-observe** completes the stack: OTel traces spanning from query intake through retrieval through graph exploration through feedback, with Grafana dashboards tracking latency distributions and posterior drift, and Jaeger for per-invocation trace waterfall. **cadence**, the newest layer, is a signal bus for ambient agency — event-driven coordination across agent workloads.
+
+These map directly to what the Agent Platform team is building. bilrost's containment model — profile-based config, network isolation, defense-in-depth — is the same problem space as hosting agents in Firecracker microVMs across global data centers. Vindler's lifecycle management is agent orchestration. qortex-observe is the telemetry layer that makes hosted agents debuggable in production.
+
+I want to be direct about a gap: Go is not yet in my production stack. Python and TypeScript are daily drivers, and Rust is the active learning language. But Go's concurrency model — goroutines and channels — maps directly to the async agent workload patterns I've already built, and its simplicity relative to Rust makes the ramp realistic. I'd expect to be writing production Go within the first month. The harder ramp is LiveKit's real-time media infrastructure, not the language.
+
+LiveKit is building the hosting platform for the kind of agents I've been building the containment and observability layer for. The parallel isn't abstract — it's three shipped projects deep. I want to work where the performance requirements are real, not hypothetical, and where agent safety is an engineering constraint enforced at the platform level.
+
+Peleke Sengstacke
+
+---
+
+## Application Form Notes
+
+| Field | Value |
+|-------|-------|
+| **Name** | Peleke Sengstacke |
+| **Portfolio** | https://peleke.dev |
+| **GitHub** | https://github.com/Peleke |
+| **Location** | Syracuse, NY (temporarily); home base Atlanta, GA |
+| **Work Authorization** | US Citizen (no sponsorship needed) |
+| **Availability** | Immediate |
+
+### If there is a free-text "Why LiveKit?" or "Additional Info" field:
+
+> I've been independently building the same stack LiveKit's Agent Platform team is productionizing: a hardened VM sandbox for agent containment (bilrost — STRIDE threat model, per-tool network isolation, published on PyPI), a production agent runtime with lifecycle management (Vindler — 90 merged PRs, OTel instrumentation), and full observability tracing agent behavior from invocation through feedback (qortex-observe — Grafana, Jaeger, Prometheus). The containment and observability aren't afterthoughts — they're the architecture. I want to bring that defense-in-depth thinking to LiveKit's agent hosting at production scale.
+
+---
+
+## Key Links to Include
+
+| What | URL |
+|------|-----|
+| Portfolio | https://peleke.dev |
+| GitHub | https://github.com/Peleke |
+| bilrost (sandbox) | https://pypi.org/project/bilrost/ |
+| qortex (retrieval + observability) | https://pypi.org/project/qortex/ |
+| LiveKit Agent Platform JD | https://jobs.ashbyhq.com/livekit/f152aa9f-981c-4661-99d3-6837654b9c8b |
+| LiveKit Agents JD | https://jobs.ashbyhq.com/livekit/1757f49e-7e19-4c45-85f7-e4637dff66fb |
+
+---
+
+## Interview Prep Quick Sheet
+
+### 30-Second Pitch
+
+"I've spent the past year building agent infrastructure from scratch — a hardened VM sandbox for agent containment, a production runtime for agent lifecycle management, and full OpenTelemetry instrumentation tracing agent behavior end-to-end. When I saw LiveKit's Agent Platform role, the alignment was immediate: you're productionizing the same architecture — containment, orchestration, observability — at the scale where it actually matters. I bring the systems thinking and security discipline. LiveKit brings the real-time constraints and production traffic that make the engineering harder and more interesting. Go is the one gap, and the ramp is realistic given my trajectory through Python, TypeScript, and Rust."
+
+### 5 Most Likely Questions and Answers
+
+**1. "Walk us through your agent infrastructure. How do the pieces fit together?"**
+
+Three layers, each built because the previous one needed it. bilrost is the containment layer: Lima VM provides the outer boundary, OverlayFS prevents persistent filesystem modification, Docker dual-container isolation gives each agent workload its own environment — air-gapped by default, bridged only per-tool via UFW firewall rules. Gated sync means nothing leaves the sandbox without explicit approval. The design started from a STRIDE threat model — I wrote five PoC exploits before I wrote the containment code.
+
+Vindler sits inside that sandbox as the runtime layer: production loop, tool dispatch, lifecycle management. Ninety merged PRs, not a prototype. qortex-observe is the instrumentation layer: OTel spans on every agent action — retrieval scores, edge weights, latency breakdowns, tool call results — all as structured span attributes, not log lines. Grafana shows aggregates, Jaeger shows individual traces. Each layer was built because the previous one needed it — you can't observe what you can't contain, and you can't contain what you can't run.
+
+**2. "You don't know Go. LiveKit is a Go shop. How do you plan to ramp up?"**
+
+I work across Python and TypeScript daily, and Rust is the active learning language. Go is syntactically simpler than Rust, and the concurrency model — goroutines and channels — maps directly to the async agent workload patterns I've already built. The concurrency primitives are more explicit than Python's asyncio, which I'd consider an advantage for the kind of concurrent agent session management LiveKit needs. I'd expect to be writing production Go within the first month. The harder ramp is LiveKit's real-time media stack and the specifics of your Firecracker integration, not the language. I'm a fast learner who picks up new languages and tools routinely — that's how I work.
+
+**3. "How do you think about deploying agents safely across global data centers?"**
+
+Safety at scale requires defense-in-depth, not a single isolation boundary. At the infrastructure level, each agent workload needs its own resource boundary — that's what Firecracker microVMs give you. Inside that boundary, you need filesystem isolation so one agent's state can't leak to another. Network isolation so agents can only reach the services they're authorized to use. And resource limits so a runaway agent can't starve its neighbors.
+
+bilrost implements this pattern at single-node scale: Lima VM as the outer boundary, OverlayFS for filesystem isolation, per-tool UFW rules for network isolation, gated sync for data egress control. The architecture translates to multi-node — the isolation primitives change (Firecracker instead of Lima, Temporal workflows instead of local orchestration), but the defense-in-depth principle is the same. The piece I haven't built yet is the scheduling layer: deciding which data center, which node, which resource pool. That's the scale problem I'd be solving at LiveKit.
+
+**4. "Tell us about a hard technical problem you solved and how you approached it."**
+
+Composing three retrieval signals — vector similarity, Personalized PageRank, and Thompson Sampling — into a single ranking that's better than any individual signal. The math for each is well-studied, but the composition is an open design question. Each signal has different units, different distributions, different failure modes.
+
+I solved it empirically: controlled benchmark with a 20-concept domain and distractors, ablation tests isolating each signal's contribution, convergence analysis over 30 days of posterior data. The result was +22% precision, +26% recall, +14% nDCG versus vanilla cosine similarity. The lesson that transfers to platform work: the hard problems are usually in the interfaces between well-understood components, not in the components themselves. Agent hosting is the same — Firecracker, Docker, Temporal are all proven. The difficulty is in composing them into a platform that's fast, reliable, and safe simultaneously.
+
+**5. "How do you approach observability for agent systems? What would you instrument?"**
+
+Every agent action becomes an OTel span with structured attributes — not a log line, because spans compose and logs don't. For an agent hosting platform, I'd instrument: session lifecycle events (start, tool call, completion, termination), resource utilization per session (CPU, memory, network), latency breakdowns at every boundary crossing (agent to tool, agent to model, agent to storage), error rates and failure modes by category, and tenant-level aggregates for capacity planning.
+
+The principle I follow: instrument first, decide what to dashboard later. You can always drop spans you don't need; you can't retroactively add spans you didn't capture. In qortex-observe, this approach meant I caught posterior drift I wasn't looking for — the instrumentation surfaced a pattern that no dashboard spec would have anticipated. For a hosting platform, that kind of emergent visibility is how you catch issues before customers report them.
+
+### One Question to Ask Them
+
+"How do you think about the isolation boundary between agent workloads today — is it primarily at the Firecracker VM level, or do you have additional layers inside the VM? I'm curious whether the threat model assumes agents are mutually untrusted or just untrusted relative to the host."
+
+This question signals: familiarity with defense-in-depth thinking, understanding that isolation is a spectrum (not binary), and genuine curiosity about LiveKit's specific architecture decisions. It also opens a conversation about bilrost's multi-layer isolation model.
+
+---
+
+## Location Note
+
+This is a remote role. Candidate is currently in Syracuse, NY (temporary) with home base in Atlanta, GA. US citizen, no sponsorship required, available immediately. No relocation concerns.
+
+---
+
+## Pre-Submission Checklist
+
+- [ ] Submit via Ashby: https://jobs.ashbyhq.com/livekit/f152aa9f-981c-4661-99d3-6837654b9c8b
+- [ ] Also consider applying to "Senior Software Engineer, Agents": https://jobs.ashbyhq.com/livekit/1757f49e-7e19-4c45-85f7-e4637dff66fb
+- [ ] Attach resume (infrastructure-weighted version if available)
+- [ ] Include portfolio link: https://peleke.dev
+- [ ] Include GitHub link: https://github.com/Peleke
+- [ ] Paste cover letter into any free-text field
+- [ ] If separate "Why this role?" field exists, use the short-form pitch from Application Form Notes above

--- a/skills/custom/job-search/applications/livekt-agent-platform.md
+++ b/skills/custom/job-search/applications/livekt-agent-platform.md
@@ -1,0 +1,72 @@
+# LiveKit — Senior Software Engineer, Agent Platform
+
+## Role Summary
+- **Link**: https://livekit.io/careers (HN Who's Hiring, February 2026)
+- **Location**: Remote
+- **Comp**: $120,000 - $250,000
+- **Fit Score**: 5/5
+
+## Lead Profile
+Lead with **Infrastructure**, reinforced by **Research Engineer**. LiveKit's agent platform is the hosting and lifecycle layer for autonomous voice/video AI agents — containerization, distributed computing, networking. The candidate is independently building the same kind of system: bilrost (hardened VM sandbox for agent containment), Vindler (agent runtime with production loop), and qortex-observe (OTel instrumentation for agent behavior). The research angle matters because LiveKit isn't just hosting containers — they're defining how agents run safely at scale, which requires principled thinking about containment, resource isolation, and observability.
+
+## Tailored Pitch (2-3 sentences)
+I've been building the agent infrastructure stack LiveKit is productionizing: a hardened VM sandbox (bilrost) for agent containment with per-tool network isolation, a production agent runtime (Vindler) with lifecycle management, and full OpenTelemetry instrumentation tracing agent behavior from invocation through execution through feedback. The containment and observability aren't afterthoughts — they're the architecture. LiveKit's agent platform needs the same defense-in-depth thinking I've already applied: agents that are safe by default, observable by design, and isolated per-workload.
+
+## Resume Emphasis
+1. **bilrost** — Lima VM sandbox with per-tool network isolation, OverlayFS containment, gated sync, and STRIDE threat model. Single-command provisioning (`bilrost up`). Published on PyPI. This is the direct analog to LiveKit's agent hosting: safe containment for autonomous code execution.
+2. **Vindler (openclaw)** — Production agent runtime with OTel instrumentation, 90 merged PRs. The operating system layer for multi-agent coordination. Maps to LiveKit's agent lifecycle management: how agents start, run, communicate, and terminate.
+3. **qortex-observe** — Full OTel pipeline (Grafana, Jaeger, Prometheus) tracing from query through retrieval through graph explore through feedback. Monitoring agents in production is the core capability LiveKit's platform needs to expose to customers.
+4. **MCP server** — Cross-language stdio transport, Python-TypeScript bridge, 29 tool calls in 3.94s. Demonstrates building the communication layer between agent runtimes and external services — the integration surface LiveKit's agents need.
+5. **Framework adapters** — 7 frameworks, 100+ CI tests, all passing framework-authored test suites. Evidence of building platform-level abstractions that work across diverse agent runtimes.
+6. **qortex** — Thompson Sampling on knowledge graph edges, real-time learning from feedback. Demonstrates the depth of agent systems thinking — not just hosting agents, but understanding what agents need from their platform.
+
+## Proof Point Mapping
+| Requirement | Evidence | Strength |
+|-------------|----------|----------|
+| Agent platform infrastructure | bilrost (VM sandbox), Vindler (agent runtime), qortex-observe (instrumentation). Three layers of agent infrastructure built from scratch. | strong |
+| Containerization and isolation | bilrost: Lima VM + OverlayFS + Docker dual-container isolation. Air-gapped by default, bridge only per-tool. STRIDE threat model with 7 analysis documents, 5 PoC exploits. | strong |
+| Distributed computing / networking | MCP stdio transport bridging Python and TypeScript. Per-tool network isolation via UFW firewall rules. Distributed qortex service (REST/GraphQL) in active development. | moderate |
+| Real-time systems | qortex graph explore: 0.02ms median latency. Feedback recording: <0.01ms. The performance discipline for real-time agent hosting is demonstrated. | moderate |
+| Python and Rust | Strong Python (primary language across all projects). Actively learning Rust, planning a Rust runtime to replace the current Python layer. Natural trajectory toward LiveKit's systems language needs. | moderate |
+| Production agent systems | Vindler: 90 merged PRs, production loop, OTel instrumentation. Not a prototype — a running system with real telemetry data and 30 days of posterior divergence evidence. | strong |
+| Observability and monitoring | qortex-observe: OTel traces spanning full agent lifecycle. Grafana dashboards for latency, feedback rates, posterior drift. Jaeger for per-invocation trace waterfall. | strong |
+| Security thinking | STRIDE threat model for agent containment. Found that workspace files injected into system prompts create an attack surface. Built per-tool network policies instead of patching. Defense-in-depth by design. | strong |
+
+## Why This Role (authentic)
+LiveKit is building the hosting platform for the kind of agents I've been building the containment and observability layer for. The parallel isn't abstract — bilrost exists because I needed to answer "how do you safely run autonomous code that makes its own tool calls?" and LiveKit is answering the same question for voice/video AI at production scale. The real-time angle is what makes this compelling: voice agents can't tolerate the latency budgets that text agents can, which means the platform layer has to be faster and the isolation has to be lighter. That constraint makes the engineering harder and more interesting. I want to work on agent infrastructure where the performance requirements are real, not hypothetical.
+
+## Gap Analysis
+| Gap | How to Frame |
+|-----|-------------|
+| No Go experience (LiveKit is a Go shop) | Strong Python, strong TypeScript, actively learning Rust. Go is the natural next addition — syntactically simpler than Rust, and the concurrency model (goroutines) maps to the concurrent agent workload management I've already built in Python with async. Trajectory is toward systems languages. |
+| No real-time voice/video experience | The containment and observability patterns are domain-agnostic. The gap is protocol-specific knowledge (WebRTC, SIP). Frame as: I bring the agent platform thinking, and the real-time media layer is learnable domain knowledge. |
+| No production distributed systems at scale | All infrastructure work is single-node. Active work on distributed qortex service (REST/GraphQL, configurable storage backends). The architecture patterns transfer; the operational experience at LiveKit-scale is what I'd gain. |
+| Work is all self-directed, not on a platform team | Every design decision was mine — including the wrong ones. Vindler's 90 merged PRs show sustained execution. The gap is collaborating on shared platform infrastructure, which is why joining a team is the right next step. |
+
+## If They Ask X, Say Y
+- **"Walk us through your agent infrastructure."** -- Three layers. bilrost is the containment layer: Lima VM with OverlayFS, Docker dual-container isolation, per-tool network policies via UFW. Vindler is the runtime layer: production loop, tool dispatch, lifecycle management. qortex-observe is the instrumentation layer: OTel spans on every agent action, Grafana dashboards, Jaeger traces. Each layer was built because the previous one needed it — you can't observe what you can't contain, and you can't contain what you can't run.
+
+- **"Why LiveKit? Why agent platform specifically?"** -- Because I've been building this independently and I know the hard problems aren't the ones I've solved yet. Single-node containment works. What I haven't done is multi-tenant isolation at scale, or agent lifecycle management under real-time latency constraints, or resource scheduling across thousands of concurrent agent sessions. LiveKit is where those problems are real.
+
+- **"You don't know Go. How do you plan to ramp up?"** -- I work across Python and TypeScript daily, with Rust as the active learning language. Go is syntactically simpler than Rust and the concurrency model — goroutines and channels — maps directly to the async agent workload patterns I've already built. I'd expect to be writing production Go within the first month. The harder ramp is LiveKit's real-time media stack, not the language.
+
+- **"Tell us about your containment/security work."** -- bilrost started from a STRIDE threat model — I enumerated the attack surfaces of running autonomous agents (network exfiltration, filesystem escape, resource exhaustion, prompt injection via workspace files) and built walls for each. Lima VM provides the outer boundary. OverlayFS prevents persistent filesystem modification. UFW rules give each tool its own network policy. Gated sync means nothing leaves the sandbox without explicit approval. Five PoC exploits validated the threat model before I wrote the containment code.
+
+- **"How do you think about agent lifecycle management?"** -- An agent needs to start (provision resources, load context), run (dispatch tools, handle errors, maintain state), and terminate (release resources, persist results, report telemetry). Vindler handles this as a production loop. The interesting design question is failure modes: what happens when an agent hangs, when a tool call times out, when the agent wants to spawn sub-agents? Those are the questions that make a hosting platform hard.
+
+- **"What's the hardest technical problem you've solved?"** -- Composing three retrieval signals — vector similarity, Personalized PageRank, and Thompson Sampling — into a single ranking that's better than any individual signal. The math for each is well-studied, but the composition is an open design question. I solved it empirically: controlled benchmark, ablation tests, convergence analysis. The +22% precision came from getting the weighting right. The lesson for platform work: the hard problems are usually in the interfaces between well-understood components, not in the components themselves.
+
+- **"How do you approach observability for agent systems?"** -- Every agent action becomes an OTel span with structured attributes — not a log line, because spans compose and logs don't. Retrieval scores, edge weights, latency breakdowns, tool call results all live as span attributes. Grafana shows aggregates (P50/P99 latency, feedback rates). Jaeger shows individual traces. The principle is: instrument first, decide what to dashboard later. You can always drop spans you don't need; you can't retroactively add spans you didn't capture.
+
+## Cover Letter Hooks
+- I've been building a parallel version of LiveKit's agent platform independently: a hardened VM sandbox for agent containment (bilrost), a production runtime for agent lifecycle management (Vindler), and full OTel instrumentation tracing agent behavior from invocation through feedback (qortex-observe).
+- When I needed to answer "how do you safely run autonomous code that makes its own tool calls?", I started with a STRIDE threat model, wrote five proof-of-concept exploits, and then built the containment — Lima VM, per-tool network isolation, gated sync, OverlayFS. The same question, at production scale with real-time latency constraints, is what LiveKit's agent platform team is solving.
+- The numbers from my agent infrastructure work: 0.02ms median graph explore latency, 29 MCP tool calls in 3.94s, 117 passing tests on the network isolation layer. I build agent systems with the same performance discipline that real-time voice/video demands.
+- I don't just build agents — I build the infrastructure that makes agents safe and observable. That distinction is why LiveKit's agent platform role is the one I want.
+
+## Application Notes
+- LiveKit is a Go shop. Acknowledge this directly and frame the trajectory: Python -> TypeScript -> Rust -> Go is a natural systems language progression. The concurrent agent workload patterns already exist in the work.
+- The JD mentions "containerization, distributed computing, networking" — map these directly to bilrost (containerization), distributed qortex service (distributed computing), and MCP stdio transport + per-tool network isolation (networking).
+- Emphasize the REMOTE aspect as logistically clean — no relocation concerns, immediate start.
+- The real-time voice/video angle is LiveKit's differentiator. Acknowledge it as the learning edge rather than pretending familiarity.
+- "Building the software stack for agentic computing" is LiveKit's positioning. The candidate is doing exactly this independently — make the parallel explicit and specific, not vague.

--- a/skills/custom/job-search/applications/tensorzero-mts.md
+++ b/skills/custom/job-search/applications/tensorzero-mts.md
@@ -1,0 +1,120 @@
+# TensorZero — Founding Member of Technical Staff
+
+## Company Context
+
+TensorZero is building an open-source LLM gateway and "automated AI engineer" (Autopilot) that uses contextual bandits — Thompson Sampling, Track-and-Stop for best-arm identification — to route and optimize LLM inference. The mathematical core of their product is the same math I have been independently building into qortex: Beta-Bernoulli posteriors, Thompson Sampling on weighted edges, posterior divergence as evidence of learning. The team is extraordinary — Viraj Mehta (CMU ML PhD, data-efficient RL), Aaron Hill (Rust compiler maintainer), Andrew Jesson (Oxford PhD, Bayesian ML, causal inference, 4k+ citations), Alan Mishler (CMU Stats PhD, sequential decision making, 1.2k+ citations), Shuyang Li (Staff SWE at Google Search). This is a seed-stage company ($7.3M raised, FirstMark / Bessemer / Bedrock) with years of runway, a Rust-first codebase, and a "no distinction between engineers and researchers" culture that matches exactly how I work.
+
+## Role Summary (Rust MTS — Back-end Engineering / Systems)
+- **Link**: https://jobs.ashbyhq.com/tensorzero/6cf3673e-5377-4c22-9f0c-ebf27c8567b1
+- **Fit Score**: 3.5/5
+- **Key Requirements**: Strong systems SWE background, extensive experience with systems programming languages (Rust, C/C++, Zig), technical leadership, drive large projects from inception to deployment, in-person NYC
+- **Honest Assessment**: Domain alignment is perfect. The Rust requirement is the gap. I am actively learning Rust and planning a Rust runtime layer, but I do not have "extensive experience" — Aaron Hill maintained the Rust compiler in college. That is the bar on this team.
+
+## Role Summary (ML MTS — ML Engineering / Research)
+- **Link**: https://jobs.ashbyhq.com/tensorzero/93f2c500-3520-4817-aaeb-311d3a012295
+- **Fit Score**: 5/5
+- **Key Requirements**: ML engineering or research background, advanced inference strategies (MCTS), optimization recipes (RL, APE), Bayesian methods
+- **Honest Assessment**: This is the role. Thompson Sampling on knowledge graph edge weights, Beta-Bernoulli posteriors, convergence analysis, bandit-based optimization — I have been building exactly this. The posting may be delisted (no longer on Ashby public board as of Feb 2026), which means either it was filled or folded into general MTS hiring. Worth emailing directly to ask.
+
+## Recommended Application Angle
+
+**Apply to the ML MTS role first.** If it has been filled or delisted, apply to the Rust MTS role with a cover letter that leads entirely with the ML/bandit overlap and frames the systems work as the growth vector. The pitch is the same either way: "I have been independently building the same kind of system you are building, using the same math, at a different layer of the stack." For the Rust role, be direct that Rust is a growth area, not a current strength — but the mathematical alignment means I can contribute to the optimization and inference strategy layers from day one while ramping on systems work under Aaron Hill. The "hungry for personal growth" and "opportunity to expand your skill set" language in the Rust posting suggests they are open to candidates who bring complementary strengths and grow into the systems side.
+
+If both roles are live, apply to both. The application will route to the same hiring team anyway. Let them decide where the fit is strongest.
+
+## Lead Profile
+
+**Research Engineer.** The one-liner: "Research engineer building instrumented agent systems that learn from feedback, with early evidence of principled agentic learning over context." This is the right frame because TensorZero's core product is a system that learns from feedback — they learn which LLM routes to take, I learn which retrieval paths to take. Same problem structure, same math, different application layer.
+
+## Tailored Pitch (2-3 sentences)
+
+I have been independently building the same kind of system TensorZero is building. qortex uses Thompson Sampling on knowledge graph edge weights with Beta-Bernoulli posteriors to make retrieval learn from usage feedback — the same math TensorZero uses for contextual bandits in LLM routing, applied at the retrieval layer instead of the inference layer. I have 30 days of production posterior divergence as evidence, controlled benchmarks (+22% precision, +26% recall, +14% nDCG vs vanilla cosine), and a published convergence analysis with interactive Beta distribution visualizations.
+
+## Resume Emphasis
+
+1. **qortex** — Thompson Sampling on edge weights, Beta-Bernoulli posteriors, PPR, posterior divergence tracking. Maps directly to TensorZero's contextual bandit core. Same math, different layer.
+2. **Convergence analysis & measurement** — Closed-loop evaluation with precision/recall/nDCG on controlled domains. Interactive Beta distribution widget (Canvas API, Lanczos lnGamma). Demonstrates the "measure everything" discipline TensorZero needs.
+3. **Framework adapters (7 frameworks, 100+ CI tests)** — Shows ability to build integrations at scale across diverse interfaces. Relevant to TensorZero's gateway needing to interface with every LLM provider.
+4. **buildlog gauntlet** — Bandit-based reviewer selection. 16K lines, partially deprecated. The surviving insight (the problem is bandit selection over context) is directly relevant to TensorZero's approach.
+5. **Interlinear** — Thompson Sampling for concept mastery tracking in adaptive language learning. Second independent application of bandits, different domain entirely.
+6. **qortex-observe / OTel instrumentation** — Full observability stack (Grafana, Jaeger, Prometheus). Maps to TensorZero's observability layer.
+7. **bilrost** — Systems engineering work: VM provisioning, network isolation, STRIDE threat modeling. Demonstrates the infrastructure instinct needed for gateway-level systems.
+8. **MCP server / cross-language transport** — 29 tool calls in 3.94s, stdio transport. Relevant to the gateway's provider-agnostic interface layer.
+
+## Proof Point Mapping
+
+| Requirement | Evidence | Strength |
+|-------------|----------|----------|
+| Thompson Sampling / bandits | Beta-Bernoulli posteriors on KG edge weights, 30 days production posterior divergence, convergence analysis published | Strong — independent implementation of their core math |
+| Bayesian ML understanding | Beta distributions, posterior updates, divergence tracking, interactive Beta widget with Lanczos lnGamma | Strong — built it, visualized it, published it |
+| Optimization / feedback loops | qortex retrieval improves from usage: +22% precision, +26% recall, +14% nDCG vs vanilla cosine | Strong — measured closed-loop improvement |
+| Systems engineering | bilrost VM sandbox (Lima, Ansible, Docker dual-container, STRIDE), MCP stdio transport, CI infrastructure | Moderate — real systems work, but Python/TS not Rust |
+| Rust proficiency | Actively learning, planned runtime layer, not yet shipped production Rust | Weak — honest gap, addressed in Gap Analysis |
+| Open-source experience | PyPI packages (qortex, bilrost), 7 framework adapters passing upstream test suites, mkdocs sites | Strong — building for the OSS ecosystem |
+| Gateway / provider abstraction | 7 framework adapters with single-import swap, MCP cross-language transport | Strong — same pattern as multi-provider LLM gateway |
+| Observability | Full OTel pipeline: Grafana dashboards, Jaeger traces, Prometheus metrics, per-retrieval instrumentation | Strong — directly maps to TensorZero's observability layer |
+| A/B testing / experimentation | Bandit-based selection in buildlog gauntlet, Thompson Sampling exploration-exploitation | Moderate — implemented the math, not at production A/B scale |
+| Evaluation rigor | Controlled 20-concept benchmark domain, precision@k/recall@k/nDCG@k, overhead profiling (0.02ms median graph explore) | Strong — principled evaluation, not vibes |
+| Technical writing / communication | Published articles with convergence analysis, hand-drawn SVG diagrams, interactive widgets, "Peleke (ed: Claude)" byline | Strong — can explain the math clearly |
+| Inception-to-deployment ownership | qortex (solo, full stack), bilrost (solo, published), Vindler (90 merged PRs), all self-directed | Strong — founding-role DNA |
+
+## Why TensorZero (authentic)
+
+The mathematical overlap is not a coincidence — it is convergent problem-solving. I started from "agents do not learn from their own usage" and independently arrived at Thompson Sampling on weighted edges with Beta-Bernoulli posteriors. TensorZero started from "LLM systems do not optimize themselves" and arrived at the same math for model routing. The fact that we reached the same family of solutions from different starting points suggests a shared understanding of how adaptive systems should work.
+
+Working alongside Andrew Jesson and Alan Mishler on Bayesian ML is a genuine, specific learning opportunity I cannot get elsewhere. Jesson's work on causal inference and Bayesian deep learning, Mishler's work on sequential decision-making and uncertainty quantification — these are the people who can push my understanding of bandits from "practitioner who implements Thompson Sampling" to "researcher who knows when Thompson Sampling is the wrong choice and what to reach for instead." That is not flattery; that is an honest assessment of where my technical ceiling currently sits and where their expertise would raise it.
+
+The "no distinction between engineers and researchers" philosophy is how I already work. I built the math and I built the infrastructure. I wrote the convergence analysis and I wrote the CI pipeline. I do not identify as "engineer" or "researcher" — I identify as "person who builds systems that learn and measures whether they actually do."
+
+The stage matters too. This is a founding team building the core product. I want to build, not maintain. The open-source model means the work has to speak for itself, which is the accountability structure I prefer.
+
+## Gap Analysis
+
+| Gap | How to Frame |
+|-----|-------------|
+| Rust proficiency | Honest: I am actively learning Rust and have planned a Rust runtime layer for qortex, but I have not shipped production Rust. The team already has Aaron Hill, who maintained the Rust compiler. What I bring is the mathematical and ML layer — the optimization logic that the Rust gateway serves. I can ramp on Rust idioms faster than most because I understand the domain the Rust code is implementing. Trajectory: currently writing Rust for the planned runtime, expect working proficiency within 2-3 months of full-time immersion. |
+| NYC relocation | Currently in Austin. This is a real logistical constraint, not a dealbreaker. I am willing to relocate for the right founding role. TensorZero is in Williamsburg. Timeline: would need 4-6 weeks for relocation logistics. Be upfront about this in the application — do not let it surface as a surprise. |
+| No PhD | The ML researchers on the team (Jesson, Mishler, Mehta) all have PhDs. I do not. Frame: I arrived at the same mathematical tools independently, from an engineering direction. The work speaks — posterior divergence plots, controlled benchmarks, published convergence analysis. The ML MTS role asks for "ML engineering or research background," not a PhD specifically. |
+| Production scale | qortex benchmarks are on a controlled 20-concept domain, not millions of inferences. TensorZero serves Fortune 50 enterprises. Frame: the evaluation methodology is rigorous regardless of scale. The math does not change. Infrastructure scaling (from bilrost/OTel work) demonstrates I can think about production systems. |
+| No prior startup experience | edX is the closest — education at scale — but not a venture-backed startup. Frame: every project in the current portfolio was self-directed, solo-built, and taken from zero to published. That is the founding-team muscle. |
+
+## If They Ask X, Say Y
+
+**"Walk me through your Thompson Sampling implementation."**
+qortex maintains Beta-Bernoulli posteriors on knowledge graph edge weights. Each edge starts with a Beta(1,1) prior — uniform, no opinion. When a retrieval path gets positive feedback, the alpha parameter increments; negative feedback increments beta. At query time, Thompson Sampling draws from each edge's posterior to decide which paths to explore, naturally balancing exploitation of known-good paths with exploration of uncertain ones. Personalized PageRank then propagates these sampled weights through the graph structure. The result: retrieval that learns which context components matter for which queries, with the exploration rate decreasing as evidence accumulates. I track posterior divergence over time as evidence that the system is actually learning — the distributions move away from the prior, and they move differently for different edge types.
+
+**"How does your work relate to what we do at TensorZero?"**
+Same math, different layer. You use Thompson Sampling and contextual bandits to decide which LLM model/prompt/strategy to route an inference to, optimizing for quality, cost, and latency. I use Thompson Sampling on knowledge graph edges to decide which retrieval paths to explore, optimizing for context relevance. Both are online learning problems where you update beliefs from feedback without retraining. Both use Beta-Bernoulli posteriors. Both face the exploration-exploitation tradeoff. The difference is where in the stack the bandit operates — you are upstream (model selection), I am downstream (context selection). A complete system probably needs both.
+
+**"Your Rust experience seems limited. How would you contribute from day one?"**
+Directly: the optimization and inference strategy layer is where my mathematical background maps. I can contribute to the bandit logic, evaluation pipelines, and experimentation framework immediately — those are language-agnostic algorithms that I have already implemented. The Rust learning curve is real but bounded: I understand the domain concepts the Rust code is expressing, which means I am learning syntax and idioms, not concepts. Aaron Hill's expertise is an accelerant — learning Rust from a compiler maintainer is a different trajectory than learning it from documentation alone. I expect working proficiency for production contributions within 8-12 weeks of full-time immersion.
+
+**"Why leave Austin for NYC?"**
+For the right founding role, relocation is straightforward. The specific draw is the team — working in person with Andrew Jesson and Alan Mishler on Bayesian ML, with Aaron Hill on Rust systems, is a concentration of expertise I cannot assemble remotely or find in Austin. The in-person requirement is a feature for a founding team, not a cost. I have no constraints that make NYC infeasible.
+
+**"How do you think about the engineer vs. researcher distinction?"**
+I do not make that distinction, which is why your "no distinction between engineers and researchers" line resonated. I built the Thompson Sampling implementation AND the CI pipeline. I wrote the convergence analysis AND the Ansible provisioning. The question is always "does the system actually learn, and can I prove it?" — that requires both the mathematical reasoning and the engineering to measure it. My buildlog project is instructive: 16K lines of code trying to make LLM-as-judge work for review, and the surviving insight was that the problem is bandit selection over context. The engineering taught me the research question.
+
+**"What is the biggest technical bet you have made?"**
+Betting that the right adaptive layer for agents is not fine-tuning or prompt optimization but online learning on the retrieval graph. Everyone else is trying to make the LLM smarter. I am trying to make the context smarter — give the LLM better inputs, and the outputs improve without touching the model. The bet is that Thompson Sampling on a knowledge graph is a more data-efficient and interpretable path to agent improvement than reinforcement learning from human feedback on the model itself. qortex's numbers (+22% precision, +26% recall) on a small controlled domain suggest the bet is directionally correct. TensorZero's success with bandits for model routing is evidence from the other side — the same class of solutions works at the inference layer too.
+
+**"Tell me about working with PhDs and ML researchers."**
+My background is in linguistics and philology — Classical Latin, Old Norse/Icelandic. That is a research discipline with its own rigor (textual criticism, morphosyntactic analysis, comparative method). I transitioned to engineering but kept the research instincts: form hypotheses, design controlled experiments, measure, publish. Working with Jesson and Mishler would be the first time I have peers who can challenge me on the mathematical foundations, which is precisely what I want. I know what I do not know — I can implement Thompson Sampling, but I may not know when Track-and-Stop is a better choice, or how to extend to contextual bandits with high-dimensional context. That is what I want to learn.
+
+**"What do you know about our blog post on bandits / Track-and-Stop?"**
+Track-and-Stop for best-arm identification is a different regime than what I have been working in. My implementation uses Thompson Sampling for exploration-exploitation in a non-stationary environment (retrieval preferences change). TensorZero's use of Track-and-Stop makes sense for the model routing problem because you want to identify the best arm (best model/prompt variant) with statistical confidence, then commit. The exploration budget matters more when each arm pull costs real money (LLM inference costs). I would be curious about how you handle non-stationarity — when a model provider updates their weights, your posteriors over that arm may become stale. That is a problem I have thought about in the retrieval context.
+
+## The Mathematical Overlap Pitch
+
+I have been independently building the same kind of system TensorZero is building, using the same math, at a different layer of the stack. qortex maintains Beta-Bernoulli posteriors on knowledge graph edge weights and uses Thompson Sampling to route retrieval through paths that have earned evidence of relevance — exactly how TensorZero uses contextual bandits to route LLM inferences through model/prompt configurations that have earned evidence of quality. I arrived at this approach not because I read your blog post, but because the exploration-exploitation tradeoff in retrieval has the same structure as the exploration-exploitation tradeoff in model selection: you have uncertain beliefs about which option is best, you update those beliefs from feedback, and you need to balance learning with performance. The convergence analysis I published — with interactive Beta distribution visualizations showing posterior divergence over 30 days — is the same kind of evidence your system generates when it identifies a winning arm. Same math. Same feedback loop. Same philosophy that AI systems should learn from their own usage rather than waiting for human retraining. The difference is where the bandit sits in the stack: you optimize the inference layer, I optimize the context layer. A founding team building both layers is the obvious next step.
+
+## Application Notes
+
+- **Primary target**: ML MTS role. Check if still active — it was not on the public Ashby board as of Feb 2026. Email the founders directly (Viraj Mehta or Gabriel Bianconi) with a brief note and the mathematical overlap pitch. LinkedIn warm outreach is also viable.
+- **Secondary target**: Rust MTS role (still listed). Apply through Ashby with a cover letter that leads with the bandit/ML overlap and acknowledges Rust as the growth vector.
+- **Apply to both if both are live.** Same team, same hiring pipeline. They will route to the right fit.
+- **Timing**: The Rust MTS has been posted since Dec 2025. It is still open, which suggests they have not found the right person or are being selective. The ML role was posted and may have been filled or folded. Move quickly.
+- **Equity consideration**: Seed stage, $7.3M raised. Equity at this stage is meaningful but illiquid. Salary range ($180-250K estimated) is below Anthropic-tier base but competitive for a seed company. The equity upside is the bet — if TensorZero succeeds, the founding equity is worth multiples of the salary delta. Evaluate against total comp at Anthropic or similar, not just base.
+- **NYC logistics**: Budget 4-6 weeks for relocation from Austin. Williamsburg is a specific neighborhood — factor in housing costs (significantly higher than Austin). Be prepared to discuss timeline in the first conversation.
+- **Open-source angle**: TensorZero's codebase is public. Before applying, read the Rust gateway code on GitHub (github.com/tensorzero/tensorzero). Understanding their implementation of the bandit logic will make the mathematical overlap pitch concrete rather than abstract. Reference specific code in the cover letter if possible.
+- **The cover letter should be 4 paragraphs max**: (1) the mathematical overlap pitch, (2) what I have built and the evidence, (3) honest Rust assessment + growth trajectory, (4) why founding team + NYC.

--- a/skills/custom/job-search/applications/wandb-weave-READY.md
+++ b/skills/custom/job-search/applications/wandb-weave-READY.md
@@ -1,0 +1,107 @@
+# Weights & Biases — Software Engineer, Weave | READY TO SUBMIT
+
+**Status**: Ready to submit
+**Date prepared**: 2026-02-23
+**Posting**: https://jobs.lever.co/wandb/399888f7-31ee-4746-a351-bc135dac9344
+**Location**: San Francisco, CA (Hybrid)
+**Comp**: $177,000 - $245,000 base
+**Company note**: W&B was acquired by CoreWeave (completed May 2025). Now part of CoreWeave's end-to-end AI platform — compute + developer tooling.
+
+---
+
+## Cover Letter
+
+Dear Hiring Team,
+
+I build the kind of agent systems Weave is designed to track — and I instrument them with evaluation pipelines. I'd bring a builder's perspective to Weave's developer experience.
+
+qortex, the knowledge-graph retrieval system I built and maintain, ships adapters for seven agent frameworks — CrewAI, LangChain, LangChain.js, Agno, AutoGen, Mastra, and Smolagents — each implementing the framework's native interface so developers swap one import and gain graph-augmented retrieval with a feedback loop. I evaluate retrieval quality with controlled benchmarks: Precision@5, Recall@5, and nDCG@5 on a 20-concept domain with distractors. The results — +22% precision, +26% recall over vanilla cosine similarity — come from a three-signal composition of vector similarity, Personalized PageRank, and Thompson Sampling on Beta-Bernoulli posteriors. I track convergence over 30 days to verify the learning signal is real. This is the evaluation methodology Weave helps teams implement, and I've built it from the ground up.
+
+The Python and TypeScript depth is not surface-level. Python is my primary language: the qortex core engine, the MCP server (29 tool calls in 3.94s over real stdio transport), bilrost (agent sandbox CLI), and all packages published to PyPI. TypeScript is production, not hobby: Mastra and LangChain.js adapters implement framework-native interfaces and pass their test suites. This cross-language fluency maps directly to Weave's need for SDK parity across ecosystems.
+
+I also built qortex-observe — full OpenTelemetry instrumentation with Grafana, Jaeger, and Prometheus, tracing from query through retrieval to graph explore to feedback. That's a bespoke version of what Weave provides as a platform. I'd rather build the platform.
+
+On the open-source side, my practice mirrors W&B's: PyPI-published packages, mkdocs documentation sites, CI with latest-version framework pinning and a zero-skip policy. If CrewAI ships a breaking change, my pipeline catches it the same day. Framework adapters are my distribution strategy — the same integration-first model Weave uses to meet developers where they work.
+
+I'm excited about the CoreWeave acquisition strengthening the infrastructure underneath Weave. Compute plus developer tooling is the right combination for what AI teams actually need. I want to contribute to Weave's evaluation primitives and integrations from the inside, with the perspective of someone who builds and evaluates agent retrieval systems daily.
+
+Peleke Sengstacke
+
+---
+
+## Application Form Notes
+
+**Platform**: Lever (standard fields)
+
+| Field | Value |
+|-------|-------|
+| Full Name | Peleke Sengstacke |
+| Email | *(use primary email)* |
+| Phone | *(use primary phone)* |
+| Resume/CV | Upload current resume PDF |
+| Portfolio / Website | https://peleke.dev |
+| LinkedIn | *(use LinkedIn URL)* |
+| GitHub | https://github.com/Peleke |
+| Cover Letter | Paste cover letter above or upload |
+| How did you hear about this role? | Lever job board / W&B careers page |
+| Are you authorized to work in the US? | Yes |
+| Do you now or will you in the future require sponsorship? | No |
+| Location | Syracuse, NY (willing to relocate to San Francisco) |
+
+**Note on Lever**: Lever forms sometimes include optional fields for "additional information" or "anything else you'd like us to know." If present, use the location note below.
+
+---
+
+## Key Links to Include
+
+| Link | Context |
+|------|---------|
+| https://peleke.dev | Portfolio — case studies, technical writing, project overviews |
+| https://github.com/Peleke | GitHub — open-source work, adapter implementations |
+| https://pypi.org/project/qortex/ | PyPI — published qortex package |
+| https://pypi.org/project/bilrost/ | PyPI — published bilrost agent sandbox CLI |
+| https://peleke.dev/writing | Technical articles — feedback loops, convergence analysis, evaluation methodology |
+
+---
+
+## Interview Prep Quick Sheet
+
+### 5 Most Likely Questions and Answers
+
+**1. "Tell us about your experience building GenAI-powered applications."**
+
+qortex is a knowledge-graph retrieval system that serves as the retrieval layer for GenAI agents. It composes three signals — vector similarity, Personalized PageRank, and Thompson Sampling with Beta-Bernoulli posteriors — to rank knowledge graph edges. I built native adapters for seven agent frameworks so any agent can use qortex as its retrieval backend with a single import swap. On the evaluation side, I run controlled benchmarks with P@5, R@5, and nDCG@5 on a 20-concept domain with distractors, and track posterior convergence over 30 days to verify the learning signal. The MCP server exposes the full system over stdio transport for tool-use workflows. This is end-to-end GenAI infrastructure: retrieval, evaluation, observability, and agent integration.
+
+**2. "How do you think about building integrations with LLM frameworks like LangChain and LlamaIndex?"**
+
+The key principle is: implement the interface the framework already defines. Don't make developers learn a new API. For LangChain, I implement BaseTool. For CrewAI, I implement their Tool class. For Mastra, I implement their TypeScript tool interface. Each adapter passes the framework's own test suite, not mine — that's the quality bar. I have 100+ CI tests across all seven adapters, with latest-version framework pinning and a zero-skip policy so breaking changes surface immediately. This is exactly the integration model Weave uses: meet developers where they already work, then add value transparently. I'd apply this same approach to Weave integrations with LlamaIndex, Instructor, and whatever frameworks emerge next.
+
+**3. "Describe your Python and TypeScript experience. How deep does it go?"**
+
+Python is my primary language. The qortex core — knowledge graph construction, PPR traversal, Thompson Sampling, Beta-Bernoulli posterior updates — is all Python. The MCP server, bilrost CLI, and evaluation benchmarks are Python. Both qortex and bilrost are published on PyPI with proper packaging, versioning, and CI. TypeScript is production-grade, not supplementary: the Mastra adapter and LangChain.js adapter implement TypeScript-native framework interfaces, handle async patterns, and pass framework test suites. The MCP server's stdio transport bridges both ecosystems. I ship production code in both languages, which is what Weave needs for cross-language SDK development and parity between the Python and TypeScript SDKs.
+
+**4. "How would you approach building evaluation features for Weave?"**
+
+From the builder's perspective. Most evaluation platforms treat RAG as a black box, but retrieval quality, context relevance, and response quality are separate signals that need separate measurement. I'd push for first-class retrieval evaluation in Weave: P@k and nDCG tracking over time, context window utilization metrics, and feedback loop instrumentation that shows whether systems are actually learning. I'd also ensure the Evaluation Playground supports custom scorer functions that go beyond LLM-as-judge — sometimes you need deterministic metrics like exact-match recall on known ground truth. And TypeScript SDK parity is non-negotiable; too many AI tools are Python-first, TypeScript-eventually.
+
+**5. "Why W&B? Why now?"**
+
+W&B has the credibility and distribution to make GenAI evaluation a standard practice, not an afterthought. Weave's positioning — open-source, framework-agnostic, traces plus evaluation — is exactly right. The CoreWeave acquisition adds compute infrastructure underneath the developer tooling, which means Weave can offer end-to-end value from training to evaluation to production monitoring. I want to build evaluation tools from the perspective of someone who builds the systems being evaluated. That dual perspective — builder and instrumenter — is rare on platform teams, and it's what makes developer tools actually useful.
+
+### 30-Second Pitch
+
+"I build agent retrieval systems and evaluate them — Thompson Sampling on knowledge graphs, controlled benchmarks with P@5 and nDCG, OTel observability from query to feedback. I ship adapters for seven agent frameworks in Python and TypeScript, all passing framework test suites, all published on PyPI with CI. Weave tracks exactly the kind of systems I build. I want to bring that builder's perspective to the platform side — making Weave's evaluation primitives, integrations, and SDK better because I've felt the pain from the other direction."
+
+### One Question to Ask Them
+
+"Weave's integration model — meeting developers inside their existing framework — is core to adoption. How does the team decide which frameworks and libraries to prioritize for new integrations, and how do you balance breadth of integration coverage against depth of support for each one?"
+
+*This question signals understanding of their distribution strategy, shows you think about prioritization trade-offs, and opens a conversation where your seven-adapter experience becomes directly relevant.*
+
+---
+
+## Location Note
+
+Currently in Syracuse, NY (temporary); home base is Atlanta, GA. Open to relocating to San Francisco for a hybrid role. Realistic relocation timeline: 2-4 weeks from offer acceptance. Happy to discuss schedule and logistics.
+
+**Re: CoreWeave acquisition** — Aware that Weights & Biases was acquired by CoreWeave (completed May 2025). Excited about the combined platform: CoreWeave's compute infrastructure underneath W&B's developer tooling creates a genuinely end-to-end AI development platform. This strengthens the case for Weave as the evaluation and observability layer — it's no longer just a standalone tool, it's part of the stack.

--- a/skills/custom/job-search/applications/wandb-weave.md
+++ b/skills/custom/job-search/applications/wandb-weave.md
@@ -1,0 +1,73 @@
+# Weights & Biases — Software Engineer, Weave
+
+## Role Summary
+- **Link**: https://jobs.lever.co/wandb/399888f7-31ee-4746-a351-bc135dac9344
+- **Location**: San Francisco, CA (hybrid)
+- **Comp**: $177,000 - $245,000
+- **Fit Score**: 5/5
+
+## Lead Profile
+**Developer Tools / DevEx**, supplemented by **ML Engineer.** Weave is an open-source toolkit for tracking and evaluating GenAI applications. The role calls for deep Python and TypeScript, building GenAI-powered applications, and multi-modal evaluations. The Dev Tools profile foregrounds the SDK/adapter/framework integration work. The ML profile provides the domain credibility — the candidate doesn't just build developer tools for AI, they build the AI systems those tools track.
+
+## Tailored Pitch (2-3 sentences)
+I build the kind of agent systems Weave is designed to track — and I instrument them end-to-end. qortex ships adapters for 7 agent frameworks in Python and TypeScript, each passing the framework's own test suite, with full OTel observability from query through retrieval to feedback. I bring deep Python and TypeScript, open-source distribution practice (PyPI, mkdocs, CI), and firsthand understanding of what developers building GenAI applications actually need to measure.
+
+## Resume Emphasis
+1. **Framework adapters — the Weave integration pattern.** 7 adapters (CrewAI, LangChain, LangChain.js, Agno, AutoGen, Mastra, Smolagents) implementing native interfaces. This is exactly Weave's integration model: meet developers where they already work. One import swap. All passing framework-authored test suites.
+2. **Python + TypeScript depth.** Core engine in Python. Mastra and LangChain.js adapters in TypeScript. MCP server bridging both ecosystems over stdio. This is not "I've used both" — it's "I ship production code in both."
+3. **Evaluation pipeline expertise.** Controlled retrieval benchmarks: P@5, R@5, nDCG@5 on a 20-concept domain with distractors. Convergence analysis on posterior divergence. This is the evaluation methodology Weave helps teams implement.
+4. **Open-source practice.** PyPI-published packages (qortex, bilrost). mkdocs documentation sites. CI with latest-version framework pinning and zero-skip policy. This matches W&B's open-source culture and distribution model.
+5. **MCP server — cross-language tooling.** 29 tool calls in 3.94s. Real stdio transport. Tool schema definition and validation. This is SDK/tooling infrastructure work.
+6. **qortex-observe — GenAI observability.** Full OTel instrumentation: Grafana, Jaeger, Prometheus. Traces from query to retrieval to graph explore to feedback. The kind of telemetry Weave captures, built from scratch.
+
+## Proof Point Mapping
+| Requirement | Evidence | Strength |
+|-------------|----------|----------|
+| 4+ years SWE experience | edX (education platform engineering) + qortex ecosystem (knowledge graph, 7 adapters, MCP server, bilrost, observe) + Interlinear (NLP app) | Strong |
+| Deep Python | qortex core: knowledge graph, PPR, Thompson Sampling, Beta-Bernoulli posteriors. bilrost CLI. MCP server. All Python. PyPI published. | Direct match |
+| Deep TypeScript | Mastra adapter, LangChain.js adapter, MCP stdio transport for TypeScript ecosystems. Production TypeScript, not hobby projects. | Strong |
+| Building GenAI-powered applications | qortex is the retrieval layer for GenAI agents. 7 framework adapters power agent RAG pipelines. MCP server provides tool access. | Direct match |
+| Multi-modal evaluations | Retrieval evaluation: P@k, R@k, nDCG@k. Performance evaluation: latency percentiles. Convergence evaluation: posterior drift over 30 days. Three evaluation dimensions, quantified. | Strong |
+| LLM playgrounds / dataset editing | Controlled 20-concept benchmark domain with distractors. Dataset construction for retrieval evaluation. Interactive Beta distribution widget for convergence visualization. | Moderate — evaluation datasets, not playground UI |
+| Open-source toolkit sensibility | PyPI packages, mkdocs sites, CI with latest-version pinning, framework test suite conformance. Ships like open-source because it is. | Strong |
+
+## Why This Role (authentic)
+Weave tracks exactly the kind of systems I build. When I instrument qortex agents with OTel traces from query through retrieval to feedback, I'm building a bespoke version of what Weave provides as a platform. I've felt the pain of evaluating GenAI applications from the builder side — precision@k and nDCG are necessary but not sufficient; you need traces, you need feedback loops, you need to see how retrieval quality changes over time. Weave is building the tool I wish I had. Contributing to it from the inside, with the perspective of someone who builds and evaluates agent retrieval systems daily, is the role where my experience compounds fastest.
+
+## Gap Analysis
+| Gap | How to Frame |
+|-----|-------------|
+| No direct experience building evaluation platform UIs (playgrounds, dataset editors) | I've built the evaluation methodology and the data that feeds these UIs. Understanding what developers need to see (P@k, traces, posterior drift) is more valuable than UI framework experience, which I can learn fast. Interactive Beta distribution widget shows frontend data visualization capability. |
+| Single-developer projects vs team-scale SWE | Framework adapters require conforming to 7 external API contracts — that's cross-team interface design. edX was a large engineering org. Open-source packaging (PyPI, CI, docs) follows the same rigor as team-scale development. |
+| San Francisco hybrid — relocation may apply | Address directly. San Francisco hybrid is workable. |
+| W&B product-specific knowledge (Weave SDK internals) | I'm a user-perspective hire. I build the systems Weave tracks. Picking up the SDK internals is fast when you already understand the domain deeply. |
+
+## If They Ask X, Say Y
+1. **"How do you think about GenAI evaluation?"** → Three dimensions. Retrieval quality: P@k, R@k, nDCG@k on controlled domains with known ground truth. Performance: latency percentiles at each pipeline stage (embedding, graph explore, feedback recording). Learning: posterior convergence over time — are the Thompson Sampling weights actually diverging from priors? Each dimension needs its own measurement methodology. Weave can unify all three in one trace.
+
+2. **"Walk me through your Python and TypeScript experience."** → Python is my primary language. qortex core: knowledge graph construction, PPR traversal, Thompson Sampling with Beta-Bernoulli posteriors, MCP server, bilrost CLI — all Python, all PyPI-published. TypeScript: Mastra adapter, LangChain.js adapter, MCP stdio transport layer. These aren't ports — they implement TypeScript-native framework interfaces. I ship production code in both ecosystems, which is exactly what Weave needs for cross-language SDK support.
+
+3. **"What would you build for Weave?"** → Better evaluation primitives for retrieval-augmented systems. Most eval frameworks treat RAG as a black box. But retrieval quality, context relevance, and response quality are separate signals that need separate evaluation. I'd push for first-class retrieval evaluation in Weave: P@k tracking over time, context window utilization metrics, feedback loop instrumentation. And I'd make sure the TypeScript SDK has full parity — too many AI tools are Python-first, TypeScript-eventually.
+
+4. **"How do you approach open-source development?"** → Ship with distribution in mind. PyPI packages, mkdocs documentation, CI that pins latest framework versions with zero-skip policy. If CrewAI ships a breaking change, my CI catches it the same day. That's the rigor open-source users expect. I also think about adoption through integration — framework adapters are my distribution strategy, which is the same pattern Weave uses.
+
+5. **"Describe your experience with agent frameworks."** → I've implemented native adapters for 7: CrewAI, LangChain (Python), LangChain.js, Agno, AutoGen, Mastra, Smolagents. Each adapter implements the framework's own interface — BaseTool, Tool, custom_tool, whatever the framework expects. All pass the framework's own test suites, not mine. 100+ CI tests total. This gives me deep knowledge of how agent developers actually build, which is critical for building evaluation tools that serve them.
+
+6. **"Why W&B over other companies?"** → W&B has the credibility and the distribution to make GenAI evaluation a standard practice, not an afterthought. Weave's positioning — open-source, framework-agnostic, focused on traces and evaluation — is exactly right. I want to build evaluation tools from the perspective of someone who builds the systems being evaluated. That perspective is rare on most platform teams.
+
+## Cover Letter Hooks
+1. "I build the kind of agent systems Weave is designed to track. qortex ships retrieval adapters for 7 agent frameworks in Python and TypeScript, each passing framework-authored test suites. When I instrument these systems with OTel traces from query to feedback, I'm building a bespoke version of what Weave provides as a platform. I'd rather build the platform."
+
+2. "Most AI evaluation tools are built by platform engineers who study agent systems from the outside. I build agent retrieval systems — Thompson Sampling on knowledge graph edges, +22% precision over vanilla cosine — and evaluate them with P@k, nDCG, and convergence analysis. Bringing that builder's perspective to Weave's evaluation primitives is the contribution I want to make."
+
+3. "Deep Python, production TypeScript, 7 framework adapters, PyPI packages, and a zero-skip CI policy. I ship open-source tooling the way W&B ships open-source tooling. The match is the methodology, not just the tech stack."
+
+4. "Weave needs engineers who understand both the developer tools layer and the GenAI systems layer. I've built both: framework adapters and MCP servers on the tools side, Thompson Sampling and knowledge graph retrieval on the ML side. That dual perspective is what makes evaluation tooling actually useful."
+
+## Application Notes
+- Comp range is $177K-$245K. This is base salary; W&B equity should be factored into total comp evaluation.
+- San Francisco hybrid — confirm schedule flexibility (how many days in-office).
+- W&B is listed as a target company in both the ML Engineer and Dev Tools profiles. This is a high-priority application.
+- Weave is relatively new in W&B's product lineup — research recent Weave releases, blog posts, and GitHub activity before applying. Understanding the current state of the SDK shows genuine interest.
+- The Python + TypeScript combination is a differentiator. Many candidates have one or the other. Having production code in both, with framework adapter experience, is uncommon.
+- Open-source contributions to Weave before or during the application process would be a strong signal. Review the Weave GitHub repo for good first issues.

--- a/skills/custom/job-search/assets/anthropic-ramp.md
+++ b/skills/custom/job-search/assets/anthropic-ramp.md
@@ -1,0 +1,215 @@
+# Anthropic Interview Prep — 6-9 Month Ramp
+
+Target roles: AI Observability RE ($320-405K), Platform/Toolbox SWE ($320-405K), Autonomous Agent Infra ($320-485K)
+
+## The Honest Assessment
+
+**What you have (most candidates don't):**
+- Novel applied research: Thompson Sampling on retrieval edges — nobody else is doing this
+- Published technical writing with real data (convergence plots, interactive widgets, not vibes)
+- Production OTel instrumentation on AI systems (AI Obs team's exact problem)
+- MCP implementation experience (Toolbox team's exact protocol)
+- 7 framework adapters passing framework-authored test suites (engineering discipline signal)
+- Feedback loop article, hand-drawn SVG diagrams, interactive Beta distribution widget
+
+**What you're missing:**
+- DSA fluency under time pressure
+- ML theory crispness (you USE the concepts but can't whiteboard proofs on demand)
+- System design interview muscle (you can design systems, you haven't practiced the 45-minute format)
+- Scale stories ("here's how I'd take qortex to 10M queries/day")
+- Coding speed (clean Python solutions to hard problems in 30 min)
+
+## Phase 1: Foundation (Months 1-2)
+
+### DSA — Build the Floor
+
+**Resource**: Neetcode 150 (neetcode.io)
+**Pace**: 2-3 problems/day, Python only
+**Focus order**:
+1. Arrays & Hashing (weeks 1-2) — this is the foundation for everything
+2. Two Pointers + Sliding Window (weeks 2-3) — pattern recognition
+3. Stack (week 3) — clean thinking
+4. Binary Search (week 4) — precision
+5. Trees (weeks 5-6) — recursive thinking
+6. Graphs (weeks 7-8) — you already think in graphs (qortex)
+
+**Method**:
+- Set a 25-minute timer. If you can't solve it, read the solution.
+- Understand WHY the solution works. Write the intuition in one sentence.
+- Re-solve from scratch the next day without looking.
+- Track: date, problem, solved (Y/N), time, pattern category
+
+**Target by end of Month 2**: Solve any Neetcode medium in 20 minutes cold.
+
+### ML Fundamentals — Get Crisp
+
+**Resource**: Chip Huyen "Machine Learning Interviews" book + Andrew Ng's CS229 notes
+**Pace**: 30 min/day reading + notes
+**Topics in order**:
+1. Supervised learning basics (bias-variance, overfitting, regularization)
+2. Evaluation metrics (precision, recall, F1, nDCG — you know these, now explain them cleanly)
+3. Gradient descent + optimization (SGD, Adam, learning rate schedules)
+4. Probabilistic models (Bayesian inference, conjugate priors — THIS IS YOUR STRENGTH, sharpen it)
+5. Bandits & reinforcement learning (Thompson Sampling, UCB, regret bounds — own this chapter)
+6. Information retrieval (TF-IDF, BM25, embedding models, re-ranking — own this too)
+
+**Method**:
+- For each topic, write a 1-paragraph explanation as if it's a section of your feedback loop article
+- Practice explaining it out loud (record yourself, cringe, get better)
+- Know the math well enough to write it on a whiteboard, not well enough to prove theorems
+
+**Target by end of Month 2**: Explain any ML fundamental in 2 minutes without notes.
+
+## Phase 2: Interview Patterns (Months 3-4)
+
+### DSA — Push to Hard
+
+**Resource**: Neetcode 150 (finish it) + blind 75 hard problems
+**Pace**: 2 problems/day, one medium one hard
+**Focus**:
+1. Dynamic Programming (weeks 1-3) — the big boss. Start with 1D, then 2D, then optimization.
+2. Heap / Priority Queue (week 4) — scheduling problems
+3. Advanced Graphs (weeks 5-6) — Dijkstra, topological sort, union find
+4. Intervals + Greedy (week 7) — pattern matching
+5. Tries + Backtracking (week 8) — completeness
+
+**Method**:
+- Hard problems: 45 minutes max before reading solution
+- Focus on recognizing the PATTERN, not memorizing solutions
+- After solving: write a one-line note on which pattern this uses
+- Weekly review: re-solve 5 problems from previous weeks
+
+**Target by end of Month 4**: Solve any Neetcode hard in 35 minutes. Not all of them — but most.
+
+### System Design — Build the Muscle
+
+**Resource**: "Designing Data-Intensive Applications" (Kleppmann) + Alex Xu "System Design Interview"
+**Pace**: 1 design session per week (timed, 45 minutes)
+**Method**:
+1. Pick a system (start with qortex — you already know it)
+2. Set 45-minute timer
+3. Talk out loud. Requirements → high-level design → deep dive → tradeoffs
+4. Record yourself. Listen back. Notice where you ramble or get vague.
+5. Practice with a friend if possible (Pramp, interviewing.io, or just a buddy)
+
+**Systems to practice** (in order):
+1. qortex at scale (retrieval system with feedback loop, 10M queries/day)
+2. Agent observability platform (Anthropic AI Obs — literally the job)
+3. MCP gateway (multi-tenant, isolated execution environments — Toolbox team)
+4. Distributed knowledge graph with real-time updates
+5. ML model serving platform with A/B testing and bandit routing
+6. Event-driven agent monitoring system (traces, alerts, anomaly detection)
+
+**Target by end of Month 4**: Deliver a clean 45-minute system design for any of these without notes.
+
+## Phase 3: Anthropic-Specific Prep (Months 5-6)
+
+### Research the Teams
+
+- Read every Anthropic engineering blog post (https://www.anthropic.com/research)
+- Understand Claude's architecture at a high level (Constitutional AI, RLHF, context windows)
+- Read the MCP specification (you already know it, but be able to discuss design decisions)
+- Read Anthropic's safety research (not to become an expert, but to speak fluently about alignment)
+
+### Practice the Anthropic Interview Format
+
+Anthropic interviews typically include:
+1. **Phone screen** — 30 min, background + motivation + high-level technical
+2. **Technical screen** — 45-60 min, coding problem (medium-hard Python)
+3. **System design** — 45-60 min, design a system relevant to the team
+4. **ML/Research deep-dive** — discussion of your work, go deep on one project
+5. **Team/culture fit** — collaboration, values, why Anthropic
+
+**For each round, practice**:
+- Phone screen: your 2-minute pitch, tailored to the specific role
+- Technical: 3 practice problems per week, timed, in a Google Doc (not an IDE)
+- System design: the 6 systems above, one per week
+- Deep-dive: practice walking through Thompson Sampling + PPR + convergence in 15 minutes
+- Culture: why safety matters to you (genuinely — not rehearsed corporate answers)
+
+### Polish Your Portfolio
+
+By month 5-6, you should have:
+- The feedback loop article (done)
+- The "Agents Don't Learn" polemic (in progress)
+- 2-3 more technical articles (from the 5-part series?)
+- qortex docs polished and deployed
+- Lab page with screenshots (Grafana, Jaeger, Memgraph dashboards)
+- A clean GitHub profile with pinned repos
+
+### Apply
+
+**Month 6**: Apply to AI Observability and/or Platform/Toolbox specifically.
+- You have a Tier A job (income, "currently employed" signal)
+- Your portfolio has 6 months more published work
+- Your DSA is at hard level
+- Your system design is practiced
+- Your ML fundamentals are crisp
+
+**Month 7-9**: Interview. You're ready.
+
+## The Performance Ramp: Camera → Twitch → Interviews
+
+The interview is a performance. Train it like one.
+
+### Stage 1: Private Camera (Months 1-2)
+- Solve problems on camera (phone recording, screen share, whatever)
+- Talk out loud. Explain your thinking. Get comfortable being watched.
+- Weekly "test": pick a random medium, 25-minute timer, film it start to finish
+- Watch it back. Notice where you go silent, where you panic, where you ramble
+- Target: solve a medium on camera without freezing
+
+### Stage 2: Recorded Reviews (Months 3-4)
+- Record yourself doing hard problems. Edit if you want, or post raw.
+- Share with friends for feedback (or a small Discord)
+- Weekly test: 1 hard problem, 45-minute timer, filmed
+- Target: clean narration through a hard problem, even if you don't solve it
+
+### Stage 3: Live on Twitch (Months 5+)
+- Stream DSA sessions live. Chat can watch you think.
+- This is the final boss of interview anxiety — if you can solve problems with randos roasting you, a quiet Zoom with a recruiter is a vacation
+- Bonus: this builds an audience and a reputation ("the guy who preps in public")
+- Weekly: 1-2 live sessions, mix of medium and hard
+- Target: confident enough to say "I stream this live, here's my Twitch" in an interview
+
+### Why this works
+Interview anxiety = performing under observation. Every stage increases the observation pressure until the actual interview feels easy by comparison. By month 6 you're not "prepping for interviews," you're a guy who solves problems on camera for fun.
+
+## Weekly Schedule Template
+
+| Day | Morning (1hr) | Evening (30min) |
+|-----|--------------|----------------|
+| Mon | DSA: 2 problems | ML reading + notes |
+| Tue | DSA: 2 problems | ML reading + notes |
+| Wed | System design mock (45 min) | Review DSA from Monday |
+| Thu | DSA: 2 problems | ML reading + notes |
+| Fri | DSA: 1 hard problem (45 min) | Re-solve week's hardest problem |
+| Sat | System design: practice walk-through | Anthropic blog post reading |
+| Sun | Rest or light review | Rest |
+
+Total: ~10 hours/week. Sustainable alongside a job.
+
+## Resources
+
+- **DSA**: neetcode.io, LeetCode premium (optional), "Cracking the Coding Interview" (reference)
+- **ML**: Chip Huyen "ML Interviews", CS229 notes, Sutton & Barto ch. 2-3 (bandits), Bishop ch. 1-4 (fundamentals)
+- **System Design**: Kleppmann "DDIA", Alex Xu "System Design Interview" vol 1 & 2, ByteByteGo YouTube
+- **Mock Interviews**: Pramp (free), interviewing.io, or trade with a friend
+- **Anthropic-Specific**: anthropic.com/research blog, MCP spec, Claude model card
+
+## Success Metrics
+
+| Month | DSA | ML | System Design | Performance | Portfolio |
+|-------|-----|-----|--------------|-------------|-----------|
+| 1 | Can solve easies cold | Reading fundamentals | — | Solving on camera (private) | — |
+| 2 | Mediums in 20 min | Explain any fundamental in 2 min | First mock (qortex) | Weekly filmed tests | — |
+| 3 | Mediums in 15 min, starting hards | Whiteboard basics | 2 more mocks | Recorded reviews | 1 new article |
+| 4 | Hards in 35 min | Crisp on bandits + IR | Clean 45-min session | Sharing recordings | 2 articles |
+| 5 | Consistent hard solves | Own the Thompson Sampling chapter | 4 practiced systems | **Twitch live sessions** | Lab screenshots done |
+| 6 | Interview-ready | Interview-ready | 6 systems done | Twitch regular | 3+ articles, clean GH |
+
+## The Mindset
+
+You are not starting from zero. You built a novel retrieval system. You published real data. You instrumented it with OTel. You wrote adapters for 7 frameworks. You just haven't practiced the interview format.
+
+The interview is a performance. The work is real. Prepare for the performance.

--- a/skills/custom/job-search/assets/proof-points.md
+++ b/skills/custom/job-search/assets/proof-points.md
@@ -1,0 +1,69 @@
+# Proof Points — Master Evidence List
+
+Citable numbers and evidence, organized by domain. Use these in application briefs, cover letters, and interview prep.
+
+## Retrieval Quality
+
+- **+22% precision** vs vanilla cosine similarity (P@5, controlled 20-concept domain)
+- **+26% recall** vs vanilla cosine similarity (R@5)
+- **+14% nDCG** vs vanilla cosine similarity (nDCG@5)
+- Controlled benchmark: 20-concept authorization domain with distractors
+- Three-signal composition: vector similarity + PPR + Thompson Sampling
+
+## Performance / Overhead
+
+- Graph explore overhead: **0.02ms median** (embedding is 99.5% of cost)
+- Feedback recording: **<0.01ms median**
+- MCP stdio transport: **29 tool calls in 3.94s** with ~400ms server spawn
+- Graph explore adds negligible latency to retrieval pipeline
+
+## Framework Adapters
+
+- **7 framework adapters**: CrewAI, LangChain (Python), LangChain.js, Agno, AutoGen, Mastra, Smolagents
+- All passing **framework-authored test suites** (not ours)
+- **100+ CI tests** across all adapters
+- Zero-skip CI policy: latest-version framework pinning
+- One import swap — implements the framework's native interface
+
+## Thompson Sampling / Learning
+
+- Beta-Bernoulli posteriors on knowledge graph edge weights
+- **30 days of production posterior divergence** as evidence
+- Convergence analysis published with interactive Beta distribution widget
+- Same math as TensorZero's contextual bandits (different application layer)
+
+## Infrastructure / Containment
+
+- **bilrost**: single-command VM provisioning (`bilrost up/status/ssh`)
+- Profile-based management, PyPI distribution
+- STRIDE threat model for agent containment
+- Lima VM with network isolation
+- Published on PyPI: qortex, bilrost
+
+## Observability
+
+- Full OTel instrumentation: Grafana, Jaeger, Prometheus
+- Traces span from query → retrieval → graph explore → feedback
+- qortex-observe: OpenTelemetry integration for agent behavior monitoring
+- Dashboard: retrieval latency, feedback rates, posterior drift
+
+## Publications / Content
+
+- Feedback loop article with convergence analysis and 3 hand-drawn SVG diagrams
+- Interactive Beta distribution widget (Canvas API, Lanczos lnGamma approximation)
+- Annotation components for technical writing
+- Article byline: "Peleke (ed: Claude)" — human-AI collaborative writing
+
+## Prior Experience
+
+- **edX**: Education platform, content delivery at scale
+- **Linguistics/Philology**: Classical Latin, Old Norse/Icelandic, morphosyntactic analysis
+- **Interlinear**: Adaptive language learning app, CLTK + Reynir NLP pipelines
+- **Swae OS**: Federated GraphQL mesh across health data sources
+
+## Open Source
+
+- Published on PyPI: qortex, bilrost
+- mkdocs documentation sites on GitHub Pages
+- CI: latest-version framework pinning, zero-skip policy
+- Framework adapters as distribution strategy

--- a/skills/custom/job-search/profiles/dev-tools.md
+++ b/skills/custom/job-search/profiles/dev-tools.md
@@ -1,0 +1,30 @@
+# Developer Tools / DevEx Profile
+
+## One-liner
+Developer tools engineer who ships SDKs, MCP servers, and framework adapters that make complex systems feel simple.
+
+## Pitch (2-3 sentences)
+I build the interfaces between powerful systems and the developers who use them. qortex ships adapters for 7 agent frameworks, each implementing the framework's native interface so users swap one import and gain graph retrieval + a feedback loop. The MCP server bridges Python and TypeScript ecosystems over stdio transport, and bilrost provisions a hardened agent sandbox from a single CLI command.
+
+## Resume emphasis order
+1. Framework adapters — native interface implementation, CI conformance testing
+2. MCP server — cross-language transport, tool schemas, stdio bridge
+3. bilrost CLI — `bilrost up/status/ssh`, profile-based management, PyPI distribution
+4. buildlog — gauntlet review system, git hooks, developer workflow integration
+5. ComfyUI MCP — image generation via MCP tools for agent workflows
+6. Open-source practice — PyPI publishing, docs sites, CI/CD
+
+## Proof points
+- 7 framework adapters, all passing framework-authored tests
+- Published on PyPI: qortex, bilrost
+- MCP server: 29 tool calls over real stdio in 3.94s
+- bilrost: single-command provisioning, profile-based config
+- CI: latest-version framework pinning, zero-skip policy
+
+## "If they ask about X, talk about Y"
+- **"How do you think about DX?"** → Users shouldn't learn a new API. Implement the interface they already use. Pass the tests they already wrote. One import swap.
+- **"How do you handle cross-language?"** → MCP stdio transport. Same Python engine, one transport layer. Suboptimal (distributed service in progress), but for agent workflows where an LLM call is 500ms-5s, stdio overhead doesn't dominate.
+- **"Open source experience?"** → PyPI packages, mkdocs sites on GitHub Pages, CI that installs latest framework versions (not pinned). If CrewAI ships a breaking change, we know the same day.
+
+## Target companies
+Vercel, Anthropic, Cursor/Anysphere, Replit, Supabase, Clerk, Prisma, Dagger

--- a/skills/custom/job-search/profiles/infrastructure.md
+++ b/skills/custom/job-search/profiles/infrastructure.md
@@ -1,0 +1,32 @@
+# Infrastructure / Platform Profile
+
+## One-liner
+Platform engineer who built a defense-in-depth sandbox, OTel observability pipeline, and distributed agent runtime from scratch.
+
+## Pitch (2-3 sentences)
+I build the infrastructure that makes agent systems safe and observable. bilrost is a hardened VM sandbox with per-tool network isolation, OverlayFS containment, and gated sync — 117 passing tests on the network isolation layer alone. The observability stack (qortex-observe) instruments every retrieval, feedback event, and graph traversal with OpenTelemetry, shipping to Grafana/Jaeger/Memgraph dashboards.
+
+## Resume emphasis order
+1. bilrost — Lima VM, Ansible provisioning, UFW firewall, Docker dual-container isolation, gitleaks sync gate
+2. qortex-observe — OTel instrumentation, Grafana dashboards, Jaeger traces, Memgraph visualization
+3. Vindler — production agent runtime, 90 merged PRs, system integration
+4. qortex distributed service (in progress) — REST/GraphQL API layer, storage backends
+5. CI/CD — 100+ adapter tests, latest-version framework pinning, zero-skip policy
+6. Prior: edX platform engineering
+
+## Proof points
+- 117 passing tests on network isolation
+- 90 merged PRs across sandbox + agent integration
+- STRIDE threat model with 7 analysis documents, 5 PoC exploits
+- Dual-container isolation: air-gapped by default, bridge only per-tool
+- Ansible-provisioned infrastructure from a single `bilrost up` command
+- Published on PyPI as `bilrost`
+
+## "If they ask about X, talk about Y"
+- **"Tell me about your infrastructure work"** → bilrost. Defense-in-depth for agent runtimes. Lima VM + OverlayFS + Docker dual-container + gated sync. Each tool gets its own network policy.
+- **"How do you think about security?"** → STRIDE threat modeling. I found that OpenClaw's identity layer is an attack surface (workspace files injected verbatim into system prompt). Built walls instead of patches.
+- **"How do you monitor systems?"** → OTel everywhere. Every retrieval, every feedback event, every graph traversal. Grafana for metrics, Jaeger for traces, Memgraph for graph visualization.
+- **"Scale?"** → Current work is single-node. Active work on distributed qortex service (REST/GraphQL, configurable storage backends). The adapter pattern carries over.
+
+## Target companies
+Anthropic, Vercel, Modal, Fly.io, Cloudflare, Railway, Render, Datadog, Grafana Labs

--- a/skills/custom/job-search/profiles/ml-engineer.md
+++ b/skills/custom/job-search/profiles/ml-engineer.md
@@ -1,0 +1,31 @@
+# ML / AI Engineer Profile
+
+## One-liner
+ML engineer who built a knowledge graph with adaptive retrieval, framework adapters for 7 agent platforms, and a feedback loop that makes retrieval learn from usage.
+
+## Pitch (2-3 sentences)
+I build retrieval systems that improve from feedback. qortex composes vector similarity, Personalized PageRank over typed edges, and Thompson Sampling into a retrieval layer that updates itself from usage. It drops into CrewAI, LangChain, Agno, AutoGen, and Mastra via native interface adapters — passing their own test suites, not mine.
+
+## Resume emphasis order
+1. qortex — knowledge graph, PPR, Thompson Sampling, Beta-Bernoulli posteriors
+2. Retrieval quality — +22% precision, +26% recall, +14% nDCG vs vanilla cosine
+3. Framework adapters — 7 frameworks, native interfaces, 100+ CI tests
+4. MCP transport — cross-language via stdio, TypeScript adapters (Mastra, LangChain.js)
+5. Embeddings + vector search — the baseline that graph retrieval builds on
+6. NLP background — CLTK, Reynir, morphosyntactic error classification (Interlinear)
+
+## Proof points
+- Controlled retrieval benchmark: 20-concept auth domain, qortex vs vanilla cosine
+- Graph explore overhead: 0.02ms median (embedding is 99.5% of cost)
+- 7 framework adapters, all passing framework-authored test suites
+- MCP stdio transport: 29 tool calls in 3.94s with ~400ms server spawn
+- Feedback recording: <0.01ms median
+
+## "If they ask about X, talk about Y"
+- **"How does your retrieval work?"** → Three signals: vector similarity (baseline), PPR over typed edges (structural), Thompson Sampling on edge weights (adaptive). They compose.
+- **"What's novel?"** → Applying Thompson Sampling to retrieval edge weights. The math is well-studied for bandits. Using it to make a knowledge graph learn which paths matter from usage feedback is new.
+- **"How do you evaluate?"** → Precision@k, Recall@k, nDCG@k on a controlled domain with distractors. Overhead benchmarks. Framework test suite conformance. Not vibes.
+- **"NLP experience?"** → Interlinear: adaptive language learning app. CLTK + Reynir NLP pipelines for Classical Latin and Icelandic. Morphosyntactic error classification feeding Thompson Sampling for concept mastery.
+
+## Target companies
+Anthropic, Cohere, Pinecone, Weaviate, Weights & Biases, Hugging Face, LangChain, Databricks

--- a/skills/custom/job-search/profiles/product-engineer.md
+++ b/skills/custom/job-search/profiles/product-engineer.md
@@ -1,0 +1,29 @@
+# Product Engineer Profile
+
+## One-liner
+Product engineer who ships end-to-end — from knowledge graphs to interactive articles to adaptive language learning apps.
+
+## Pitch (2-3 sentences)
+I build products that sit at the intersection of research and users. Interlinear is an adaptive language learning app where morphosyntactic error classification feeds Thompson Sampling for concept mastery. The portfolio site features interactive data visualizations (Beta distribution widgets, animated SVG diagrams) that make dense technical concepts tangible.
+
+## Resume emphasis order
+1. Interlinear — adaptive language learning, CLTK + Reynir NLP, concept mastery tracking
+2. Swae OS — federated GraphQL mesh across health data sources, cross-domain reasoning
+3. Portfolio site — Astro, interactive MDX, hand-drawn SVG diagrams, annotation components
+4. ComfyUI MCP — image generation as agent tooling, MCP interface
+5. qortex as product — framework adapters as distribution strategy, open-core model
+6. Prior: edX — education platform, content delivery at scale
+
+## Proof points
+- Interlinear: Classical Latin + Icelandic NLP pipelines, adaptive difficulty
+- Portfolio: interactive Beta distribution widget, 4 hand-drawn SVG diagrams, annotation tooltips
+- ComfyUI MCP: agent-driven image generation via MCP tools
+- Swae OS: federated health data mesh (in progress)
+
+## "If they ask about X, talk about Y"
+- **"How do you think about product?"** → Research tooling nobody cares about unless you show value in one plot and six bullet points. The product surfaces are where the stack gets stress-tested.
+- **"Full-stack?"** → Astro + TypeScript frontend, Python backend (qortex), Rust (planned), Ansible infra. Whatever the product needs.
+- **"How do you prioritize?"** → Distribution over polish. Framework adapters exist so qortex can be tested across real applications. Products exist so the learning layer has real feedback signals.
+
+## Target companies
+Vercel, Linear, Notion, Figma, Replit, early-stage startups (Series A/B with real technical problems)

--- a/skills/custom/job-search/profiles/research-engineer.md
+++ b/skills/custom/job-search/profiles/research-engineer.md
@@ -1,0 +1,32 @@
+# Research Engineer Profile
+
+## One-liner
+Research engineer building instrumented agent systems that learn from feedback, with early evidence of principled agentic learning over context.
+
+## Pitch (2-3 sentences)
+I build agent systems and study how they learn. My current work (qortex) implements Thompson Sampling over knowledge graph edges to create a retrieval layer that updates itself from usage — no retraining, no LLM calls. Agents instrumented with qortex learn which context components matter for which queries in real time, with 30 days of production posterior divergence as evidence.
+
+## Resume emphasis order
+1. qortex — adaptive learning layer, Thompson Sampling, Beta-Bernoulli posteriors, PPR
+2. Evaluation + measurement — closed-loop measurement, convergence analysis, benchmark suite
+3. Framework adapters — 7 frameworks, 100+ CI tests, interface conformance
+4. Vindler — production loop, OTel instrumentation, real usage data
+5. bilrost — containment, threat modeling, STRIDE analysis
+6. Prior: edX, language background, philology
+
+## Proof points
+- Thompson Sampling on edge weights → measurable posterior divergence over 30 days
+- Retrieval quality: +22% precision, +26% recall, +14% nDCG vs vanilla cosine
+- 7 framework adapters passing their own test suites (not ours)
+- Interactive Beta distribution widget in published article
+- Feedback loop article with convergence analysis
+
+## "If they ask about X, talk about Y"
+- **"Tell me about your research"** → The learning gap in agentic AI. Agents don't learn. Here's the mechanism that makes them learn. Here's the data.
+- **"What's your most technically challenging work?"** → Thompson Sampling + PPR composition for retrieval that updates from feedback. The math is well-studied; applying it to agent context engineering is new.
+- **"How do you evaluate your work?"** → Closed-loop measurement. Precision/recall/nDCG on a controlled domain. Convergence plots. Before/after. Not vibes.
+- **"Why this role?"** → I want to work on the systems that make AI systems better. The meta-layer. How do you make agents that improve from use?
+- **"Biggest failure?"** → buildlog. 16K lines of Python trying to solve the wrong problem. What survived: the gauntlet (rule-based review). What I learned: the problem is bandit selection over context, not LLM-as-judge.
+
+## Target companies
+Anthropic, DeepMind, OpenAI (research), Cohere, AI2, FAIR, TensorZero

--- a/skills/custom/job-search/targets.md
+++ b/skills/custom/job-search/targets.md
@@ -1,0 +1,82 @@
+# Target Companies
+
+## Search Criteria
+
+- **Role fits a profile**: not "kinda sorta" — actually matches
+- **Real technical work**: agents, ML infra, retrieval, distributed systems (not GPT wrapper SaaS)
+- **Location**: Open to anywhere. Currently in Syracuse, NY (temporarily). Home base Atlanta. Loves NYC (Park Slope / PLG / Prospect Park area ideal). Will relocate for the right role.
+- **Comp floor**: Must cover living + dog (GSD, non-negotiable). Remote LCOL: $150K+. NYC: $180K+ (dog walker/daycare ~$500-1K/mo). SF: $200K+.
+- **Stage preference**: Doesn't matter. Needs income NOW — urgency is real.
+- **Dog constraint**: GSD needs daily exercise/attention. If in-person 5d/wk, need dog walker or nearby dog daycare. NYC Park Slope / Prospect Park area is ideal (park access).
+- **Interview style**: Strongest in practical/portfolio-based. Weakest in DSA/competitive math. System design is doable with prep.
+
+## Tier 1 — Dream List (apply regardless)
+
+| Company | Why | Role(s) Found | Fit | Comp | Location | Status |
+|---------|-----|--------------|-----|------|----------|--------|
+| Anthropic | The lab. OTel + agent systems + MCP. | AI Observability RE; Platform/Toolbox SWE; Autonomous Agent Infra | 5/5; 5/5; 4/5 | $320-485K | SF/NYC/SEA hybrid | Applied (RE general) |
+| TensorZero | Same math (Thompson Sampling, contextual bandits). | Founding MTS Rust; Founding MTS ML/Research | 5/5; 5/5 | $180-250K + equity | NYC 5d/wk | Researching |
+| DeepMind | Research depth. | RE, Autonomous Agents | 3/5 | Google bands | London hybrid | Deprioritized (location) |
+| Modal | Infra for ML workloads. | MTS - Systems | 3/5 | ~$200-350K+ | NYC/Stockholm | Deprioritized (narrow fit) |
+| Cohere | Retrieval, embeddings, enterprise AI. | Applied ML SE; Internal Infra SE | 3/5; 3/5 | ~$200K+ | Remote NA | Monitoring |
+
+## Tier 2 — Strong Fit
+
+| Company | Why | Role(s) Found | Fit | Comp | Location | Status |
+|---------|-----|--------------|-----|------|----------|--------|
+| Databricks | ML optimization algorithms for systems. | Sr Applied AI Engineer — ML for Systems | 5/5 | — | Mountain View | Shortlisted |
+| W&B (CoreWeave) | GenAI eval, agents, RAG tooling. | SE, Weave | 5/5 | $177-245K | SF hybrid | Shortlisted |
+| Grafana Labs | OTel differentiator. We use their stack. | Sr SE, GenAI & ML Eval Frameworks; Sr/Staff AI Engineer | 5/5; 4/5 | $154-185K | Remote US | Shortlisted |
+| Cursor/Anysphere | Agent learning, retrieval for code. | Research Engineer | 4/5 | — | SF in-person | Shortlisted |
+| Vercel | AI-native dev tools, TypeScript. | SE Backend Infra, v0 | 4/5 | $224-336K | Remote US | Shortlisted |
+| Replit | Agent-native IDE, Rust + TS. | SE Product Infra (TS DevEx); SE Distributed Systems | 4/5; 4/5 | $180-250K | Foster City hybrid | Shortlisted |
+| Hugging Face | Open-source ML, model hub. | Data/Infra Advocate Engineer | 3/5 | — | Remote | Monitoring |
+
+## HN Discoveries (Feb 2026)
+
+| Company | Why | Role | Fit | Comp | Location | Status |
+|---------|-----|------|-----|------|----------|--------|
+| LiveKit | Agent platform/runtime — parallel to Vindler. | Sr SWE, Agent Platform | 5/5 | $120-250K | Remote | Shortlisted |
+| Coder | Agent hosting, sandboxed execution — parallel to bilrost. | SWE, AI Tools | 5/5 | — | Remote | Shortlisted |
+| Wave | Autonomous agents + linguistics background advantage. | Applied AI Engineer | 5/5 | up to $222K + equity | Remote US | Shortlisted |
+| deepset (Haystack) | RAG/agent systems, framework expertise. | Forward Deployed Engineer | 5/5 | — | Remote EU/UK | Shortlisted (location TBD) |
+| Zed Industries | Rust + AI, dev tools. | AI Rust Engineer | 4/5 | $170-250K | Remote | Shortlisted |
+| MS Azure Data | Vector retrieval, DiskANN, Rust. | Sr SWE, Vector DB | 4/5 | — | Redmond/Remote | Monitoring |
+| US CAISI (NIST) | AI eval + safety — mission match. | ML Engineer / MTS | 4/5 | ~$190K | SF/DC onsite | Monitoring (location) |
+
+## Tier 3 — Worth a Look
+
+| Company | Why | Profile(s) | Status |
+|---------|-----|-----------|--------|
+| Pinecone | Vector DB. Could dunk on them with graph retrieval benchmarks lol. | ML | — |
+| Weaviate | Same. | ML | — |
+| LangChain | We wrote their adapter. | DevTools, ML | — |
+| Fly.io | Edge infra. | Infra | — |
+| Railway | Deploy infra. | Infra | — |
+| Linear | Beautiful product eng. | Product | — |
+| Notion | Product eng at scale. | Product | — |
+| Supabase | Open-source infra. | Infra, DevTools | — |
+
+## Sources to Monitor
+
+- [x] Hacker News "Who's Hiring" (Feb 2026 — scanned 2026-02-23)
+- [ ] LinkedIn job alerts (set up per profile)
+- [x] Company career pages — Tier 1 scanned 2026-02-23
+- [x] Company career pages — Tier 2 scanned 2026-02-23
+- [ ] Y Combinator Work at a Startup
+- [ ] Wellfound (AngelList)
+
+## Key Links
+
+- [Anthropic AI Observability](https://job-boards.greenhouse.io/anthropic/jobs/5125083008)
+- [Anthropic Platform/Toolbox](https://job-boards.greenhouse.io/anthropic/jobs/4955107008)
+- [Anthropic Autonomous Agent Infra](https://job-boards.greenhouse.io/anthropic/jobs/5065894008)
+- [TensorZero Rust MTS](https://jobs.ashbyhq.com/tensorzero/6cf3673e-5377-4c22-9f0c-ebf27c8567b1)
+- [TensorZero ML MTS](https://jobs.ashbyhq.com/tensorzero/93f2c500-3520-4817-aaeb-311d3a012295)
+- [Databricks ML for Systems](https://www.databricks.com/company/careers/engineering---pipeline/senior-applied-ai-engineer--ml-for-systems--infrastructure-7859597002)
+- [W&B Weave](https://jobs.lever.co/wandb/399888f7-31ee-4746-a351-bc135dac9344)
+- [Grafana GenAI Eval](https://job-boards.greenhouse.io/grafanalabs/jobs/5559973004)
+- [Cursor RE](https://anysphere.inc/careers/research_engineer)
+- [Vercel v0](https://vercel.com/careers/software-engineer-backend-infrastructure-v0-us-5704297004)
+- [Replit TS DevEx](https://jobs.ashbyhq.com/replit/34afefd8-f698-4c46-a517-9ced6695b59b)
+- [Replit Distributed Systems](https://jobs.ashbyhq.com/replit/659a8e1e-69ba-44c0-a632-96665051a3e8)


### PR DESCRIPTION
## Summary
- Adds `job-search` skill with role profiles, target companies, application templates, and proof points
- Covers ML engineer, product engineer, research engineer, infrastructure, and dev tools profiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)