### PR TITLE
feat: linwheel-content-engine — SDK tools instead of curl

### DIFF
--- a/skills/custom/linwheel-content-engine/SKILL.md
+++ b/skills/custom/linwheel-content-engine/SKILL.md
@@ -1,20 +1,22 @@
 ---
 name: linwheel-content-engine
 description: >
-  Drive the LinWheel LinkedIn content engine via its REST Agent API. Analyze source
+  Drive the LinWheel LinkedIn content engine via first-class tools. Analyze source
   content, reshape it into angle-specific LinkedIn posts, refine drafts with LLM editing,
-  attach hero images and carousels, approve posts, and schedule them for auto-publish.
-  Use when the user wants to create, manage, or publish LinkedIn content through LinWheel.
+  attach hero images and carousels, manage voice profiles, approve posts, and schedule
+  them for auto-publish. Use when the user wants to create, manage, or publish LinkedIn
+  content through LinWheel.
 metadata:
   openclaw:
     emoji: "\U0001F3A1"
     requires:
-      env: ["LINWHEEL_API_URL", "LINWHEEL_API_KEY"]
+      env: ["LINWHEEL_API_KEY"]
+      tools: ["linwheel_analyze"]
 ---
 
 # LinWheel Content Engine
 
-> Turn any text into polished, scheduled LinkedIn posts via LinWheel's REST Agent API.
+> Turn any text into polished, scheduled LinkedIn posts via LinWheel tools.
 
 ## Execution Flow
 
@@ -34,6 +36,7 @@ Phase 6: Schedule — Set publish times; LinWheel's cron auto-publishes
 - Refining existing draft text with LinkedIn-optimized formatting
 - Attaching typographic hero images or carousel slides to posts
 - Managing the approval/scheduling pipeline for LinkedIn content
+- Setting up or switching voice profiles for style matching
 
 ## Trigger Phrases
 
@@ -43,64 +46,56 @@ Phase 6: Schedule — Set publish times; LinWheel's cron auto-publishes
 - "What LinkedIn drafts do I have?"
 - "Create a LinkedIn carousel from this"
 - "Pass this through linwheel"
+- "Set up my LinkedIn voice"
 
 ---
 
-## Authentication
+## Authentication & Tool Access
 
-Every request MUST include:
-
-```
-Authorization: Bearer $LINWHEEL_API_KEY
-Content-Type: application/json
-```
+Tools require `LINWHEEL_API_KEY` to be configured. No base URL needed — the SDK handles routing.
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `LINWHEEL_API_URL` | Yes | Base URL (e.g., `https://linwheel.io`) |
 | `LINWHEEL_API_KEY` | Yes | API key starting with `lw_sk_...` |
-| `LINWHEEL_SIGNING_SECRET` | No | HMAC signing secret for request signatures |
 
-### Request Template
+### Tool Name Resolution
 
-```bash
-curl -X {METHOD} "$LINWHEEL_API_URL{path}" \
-  -H "Authorization: Bearer $LINWHEEL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{body_json}'
-```
+LinWheel tools are available under different prefixes depending on the agent runtime:
+
+| Runtime | Tool Prefix | Example |
+|---------|-------------|---------|
+| **OpenClaw** (native extension) | `linwheel_` | `linwheel_analyze` |
+| **Claude Code / MCP** | `mcp__linwheel__linwheel_` | `mcp__linwheel__linwheel_analyze` |
+
+This skill uses the short `linwheel_*` names throughout. If you are in an MCP context, prepend `mcp__linwheel__` to each tool name. The parameters are identical across both runtimes.
 
 ---
 
-## API Reference
+## Tool Reference
 
 ### 1. Analyze Content
 
 Assess text for LinkedIn posting potential. Always run this FIRST on new content.
 
-```
-POST /api/agent/analyze
-```
+**Tool:** `linwheel_analyze`
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
 | `text` | string | Yes | The text content to analyze |
-| `context` | string | No | Context about the content |
+| `context` | string | No | Context about the content (e.g. "buildlog entry about shipping an MCP server") |
 
-Returns: topic relevance, suggested angles, LinkedIn fit score, recommended post count.
+Returns: topic relevance scores, suggested angles with hook ideas, LinkedIn fit score (1-10), extractable insights, recommended post count.
 
 ---
 
 ### 2. Reshape Content into Posts
 
-The primary content generation endpoint. Decompose source content into angle-specific posts.
+The primary content generation tool. Decompose source content into angle-specific posts.
 
-```
-POST /api/agent/reshape
-```
+**Tool:** `linwheel_reshape`
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
 | `text` | string | Yes | Source content to reshape |
 | `angles` | string[] | Yes | Angles to generate (see table below) |
 | `preEdit` | boolean | No | Light-edit input before reshaping (default: false) |
@@ -125,12 +120,10 @@ POST /api/agent/reshape
 
 LLM editing pass at configurable intensity.
 
-```
-POST /api/agent/refine
-```
+**Tool:** `linwheel_refine`
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
 | `text` | string | Yes | Text to refine |
 | `intensity` | string | No | `"light"`, `"medium"` (default), `"heavy"` |
 | `instructions` | string | No | Custom editing instructions |
@@ -143,12 +136,10 @@ POST /api/agent/refine
 
 ### 4. Split Long Content into Series
 
-```
-POST /api/agent/split
-```
+**Tool:** `linwheel_split`
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
 | `text` | string | Yes | Long content to split |
 | `maxPosts` | number | No | Max posts (2-10, default: 5) |
 | `instructions` | string | No | Instructions for splitting |
@@ -160,14 +151,12 @@ POST /api/agent/split
 
 Use when you already have finished post text.
 
-```
-POST /api/agent/draft
-```
+**Tool:** `linwheel_draft`
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
 | `fullText` | string | Yes | Full post text (max 3000 chars) |
-| `hook` | string | No | Opening hook line |
+| `hook` | string | No | Opening hook line (auto-extracted from first line if omitted) |
 | `postType` | string | No | Content angle (default: `"field_note"`) |
 | `approved` | boolean | No | Pre-approve (default: false) |
 | `autoPublish` | boolean | No | Auto-publish at schedule (default: true) |
@@ -175,14 +164,34 @@ POST /api/agent/draft
 
 ---
 
-### 6. List Posts
+### 6. Bundle (Post + Visuals)
 
-```
-GET /api/agent/posts
-```
+Create post + image + carousel atomically. At least one of image or carousel must be provided.
 
-| Param | Type | Description |
-|-------|------|-------------|
+**Tool:** `linwheel_bundle`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `fullText` | string | Yes | Post text |
+| `hook` | string | No | Opening hook |
+| `postType` | string | No | Content angle |
+| `approved` | boolean | No | Pre-approve (default: false) |
+| `autoPublish` | boolean | No | Auto-publish when scheduled (default: true) |
+| `scheduledAt` | string | No | ISO 8601 scheduled time |
+| `imageHeadlineText` | string | No | Hero image headline (max 200 chars). Omit to skip image. |
+| `imageStylePreset` | string | No | Image style preset |
+| `carouselSlides` | object[] | No | Carousel slides (1-10). Omit to skip carousel. |
+| `carouselSlides[].headlineText` | string | Yes | Slide headline |
+| `carouselSlides[].caption` | string | No | Slide caption |
+
+---
+
+### 7. List Posts
+
+**Tool:** `linwheel_posts_list`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
 | `approved` | `"true"/"false"` | Filter by approval |
 | `scheduled` | `"true"/"false"` | Filter by scheduled |
 | `published` | `"true"/"false"` | Filter by published |
@@ -192,63 +201,63 @@ GET /api/agent/posts
 
 ---
 
-### 7. Get a Single Post
+### 8. Get a Single Post
 
-```
-GET /api/agent/posts/{postId}
-```
+**Tool:** `linwheel_post_get`
 
----
-
-### 8. Update a Post
-
-```
-PATCH /api/agent/posts/{postId}
-```
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `fullText` | string | New post text |
-| `hook` | string | New hook line |
-| `autoPublish` | boolean | Toggle auto-publish |
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `postId` | string | Yes | The post ID to retrieve |
 
 ---
 
-### 9. Approve / Unapprove
+### 9. Update a Post
 
-```
-POST /api/agent/posts/{postId}/approve
-```
+Cannot edit posts already published to LinkedIn.
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
+**Tool:** `linwheel_post_update`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `postId` | string | Yes | The post ID |
+| `fullText` | string | No | New post text |
+| `hook` | string | No | New hook line |
+| `autoPublish` | boolean | No | Toggle auto-publish |
+
+---
+
+### 10. Approve / Unapprove
+
+**Tool:** `linwheel_post_approve`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `postId` | string | Yes | The post ID |
 | `approved` | boolean | Yes | `true` to approve, `false` to unapprove |
 
 ---
 
-### 10. Schedule / Unschedule
+### 11. Schedule / Unschedule
 
-```
-PATCH /api/agent/posts/{postId}/schedule
-```
+**Tool:** `linwheel_post_schedule`
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `postId` | string | Yes | The post ID |
 | `scheduledAt` | string/null | Yes | ISO 8601 datetime, or `null` to clear |
-| `autoPublish` | boolean | No | Toggle auto-publish |
+| `autoPublish` | boolean | No | Toggle auto-publish (default: keeps current) |
 
 A post auto-publishes when: `approved=true` AND `autoPublish=true` AND `scheduledAt` has arrived.
 
 ---
 
-### 11. Generate Hero Image
+### 12. Generate Hero Image
 
-```
-POST /api/agent/posts/{postId}/image
-```
+**Tool:** `linwheel_post_image`
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `postId` | string | Yes | The post ID |
 | `headlineText` | string | Yes | Text on image (max 200 chars) |
 | `stylePreset` | string | No | Default: `"typographic_minimal"` |
 
@@ -256,14 +265,13 @@ POST /api/agent/posts/{postId}/image
 
 ---
 
-### 12. Create Carousel
+### 13. Create Carousel
 
-```
-POST /api/agent/posts/{postId}/carousel
-```
+**Tool:** `linwheel_post_carousel`
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `postId` | string | Yes | The post ID |
 | `slides` | object[] | Yes | 1-10 slides |
 | `slides[].headlineText` | string | Yes | Slide headline |
 | `slides[].caption` | string | No | Slide caption |
@@ -273,23 +281,44 @@ First slide = title. Last slide = CTA. Middle = content.
 
 ---
 
-### 13. Bundle (Post + Visuals)
+## Voice Profiles
 
-Create post + image + carousel atomically.
+Voice profiles inject writing style into all content generation. The active profile's samples are used for style matching in reshape, refine, split, and bundle operations.
 
-```
-POST /api/agent/bundle
-```
+### List Voice Profiles
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `fullText` | string | Post text (required) |
-| `hook` | string | Opening hook |
-| `postType` | string | Content angle |
-| `approved` | boolean | Pre-approve (default: false) |
-| `image.headlineText` | string | Hero image headline (omit to skip) |
-| `image.stylePreset` | string | Image style |
-| `carousel.slides` | object[] | Carousel slides (omit to skip) |
+**Tool:** `linwheel_voice_profiles_list`
+
+No parameters. Returns all profiles with active status.
+
+### Create Voice Profile
+
+**Tool:** `linwheel_voice_profile_create`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | string | Yes | Profile name |
+| `samples` | string[] | Yes | Writing samples (3+ recommended) |
+| `description` | string | No | Style notes (e.g. "Technical, direct, slightly irreverent") |
+| `isActive` | boolean | No | Set as active profile (default: true) |
+
+### Delete Voice Profile
+
+**Tool:** `linwheel_voice_profile_delete`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `profileId` | string | Yes | The profile ID to delete |
+
+### Activate Voice Profile
+
+**Tool:** `linwheel_voice_profile_activate`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `profileId` | string | Yes | The profile ID to activate |
+
+Only one profile can be active at a time. Activating one deactivates the previous.
 
 ---
 
@@ -298,33 +327,42 @@ POST /api/agent/bundle
 ### Workflow A: Article to Multiple Posts (Standard)
 
 ```
-1. ANALYZE   — POST /api/agent/analyze (get angles + fit score)
-2. RESHAPE   — POST /api/agent/reshape (saveDrafts=true, use suggested angles)
-3. LIST      — GET  /api/agent/posts?approved=false (review drafts)
-4. REFINE    — POST /api/agent/refine (polish individual posts, intensity=medium)
-5. UPDATE    — PATCH /api/agent/posts/{id} (apply refined text)
-6. IMAGE     — POST /api/agent/posts/{id}/image (attach hero images)
-7. APPROVE   — POST /api/agent/posts/{id}/approve
-8. SCHEDULE  — PATCH /api/agent/posts/{id}/schedule (stagger across days)
+1. ANALYZE    — linwheel_analyze (get angles + fit score)
+2. RESHAPE    — linwheel_reshape (saveDrafts=true, use suggested angles)
+3. LIST       — linwheel_posts_list (approved="false", review drafts)
+4. REFINE     — linwheel_refine (polish individual posts, intensity="medium")
+5. UPDATE     — linwheel_post_update (apply refined text to each post)
+6. IMAGE      — linwheel_post_image (attach hero images)
+7. APPROVE    — linwheel_post_approve (approved=true)
+8. SCHEDULE   — linwheel_post_schedule (stagger across days)
 ```
 
 ### Workflow B: Quick Single Post
 
 ```
-1. BUNDLE    — POST /api/agent/bundle (post + image, approved=false)
-2. REVIEW    — GET  /api/agent/posts/{id}
-3. APPROVE   — POST /api/agent/posts/{id}/approve
-4. SCHEDULE  — PATCH /api/agent/posts/{id}/schedule
+1. BUNDLE     — linwheel_bundle (post + image, approved=false)
+2. REVIEW     — linwheel_post_get (check the draft)
+3. APPROVE    — linwheel_post_approve (approved=true)
+4. SCHEDULE   — linwheel_post_schedule
 ```
 
 ### Workflow C: Long Content to Series
 
 ```
-1. SPLIT     — POST /api/agent/split (saveDrafts=true)
-2. REFINE    — POST /api/agent/refine (each post)
-3. CAROUSEL  — POST /api/agent/posts/{id}/carousel (optional, first post)
-4. APPROVE   — Approve all
-5. SCHEDULE  — Consecutive business days, same time
+1. SPLIT      — linwheel_split (saveDrafts=true)
+2. REFINE     — linwheel_refine (each post)
+3. UPDATE     — linwheel_post_update (apply refined text)
+4. CAROUSEL   — linwheel_post_carousel (optional, first post)
+5. APPROVE    — linwheel_post_approve (all posts)
+6. SCHEDULE   — linwheel_post_schedule (consecutive business days, same time)
+```
+
+### Workflow D: Voice Setup
+
+```
+1. LIST       — linwheel_voice_profiles_list (check existing profiles)
+2. CREATE     — linwheel_voice_profile_create (3+ writing samples)
+3. VERIFY     — linwheel_voice_profiles_list (confirm active)
 ```
 
 ---
@@ -336,21 +374,13 @@ POST /api/agent/bundle
 - Series: consecutive business days, same time each day
 - Always create with `approved: false` first. Review, then approve separately.
 
-## Error Reference
-
-| Status | Meaning | Action |
-|--------|---------|--------|
-| 401 | Bad API key or HMAC | Check `$LINWHEEL_API_KEY` |
-| 404 | Post not found | Verify postId, list posts |
-| 422 | Validation error | Check field constraints (3000 char limit, valid angles) |
-| 429 | Rate limited | Wait and retry |
-
 ## Quality Checklist
 
 - [ ] Analyzed before reshaping (never skip analyze)
 - [ ] Angles chosen from analyze results, not guessed
 - [ ] All posts saved as drafts (`saveDrafts: true`)
 - [ ] Posts created with `approved: false`
+- [ ] Voice profile active if user has one
 - [ ] Schedule times during LinkedIn peak hours
 - [ ] No two posts from same source on same day
 - [ ] User shown summary of all created/scheduled posts


### PR DESCRIPTION
## Summary
- Replace all REST/curl API references with first-class `linwheel_*` tool invocations
- Add voice profile tools section (4 new tools: list, create, delete, activate)
- Document MCP vs OpenClaw native tool prefix resolution (`mcp__linwheel__linwheel_*` vs `linwheel_*`)
- Remove `LINWHEEL_API_URL` env requirement (SDK handles routing)
- Add `tools: ["linwheel_analyze"]` to metadata for tool dependency declaration

## Test plan
- [x] All 17 tool names present and documented
- [x] Zero curl/REST remnants (`curl`, `POST /api`, `GET /api`, `PATCH /api` — all absent)
- [x] Metadata requires only `LINWHEEL_API_KEY` (not `LINWHEEL_API_URL`)
- [x] MCP prefix section documents both runtimes
- [x] Programmatic verification script passed all checks

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)