### PR TITLE
fix: conventions updates, SVG diagrams skill expansion, pitch output schema

### DIFF
--- a/skills/custom/_conventions.md
+++ b/skills/custom/_conventions.md
@@ -56,6 +56,7 @@ Every document type maps to exactly one folder. This is the "table" in our vault
 | Content Brief | `Writing/Content-Briefs/` | `content-planner` |
 | Content Board | `Writing/Content-Plan.kanban.md` | `content-planner` |
 | Draft | `Writing/Drafts/` | `content-planner` / manual |
+| Wild Index | `Writing/From-The-Wild/` | `wild-scan` |
 | Research Note | `Writing/Research/` | manual |
 
 **Rules:**
@@ -73,7 +74,7 @@ Every document MUST have YAML frontmatter with AT MINIMUM these fields:
 ```yaml
 type: string        # one of: signal-scan | decision | persona | swot-analysis |
                     # offer-spec | pitch | community-pitch | skool-pitch |
-                    # session | content-brief | lead |
+                    # session | content-brief | wild-index | lead |
                     # conversation | draft | research-note
 date: YYYY-MM-DD    # creation date
 status: string      # see valid statuses below
@@ -97,6 +98,7 @@ tags: string[]      # MUST include hunter/{type} or content/{type} at minimum
 | lead | `cold`, `warm`, `hot`, `converted`, `lost` |
 | conversation | `active`, `stale`, `closed` |
 | draft | `wip`, `review`, `final` |
+| wild-index | `active`, `archived` |
 | research-note | `active`, `archived` |
 
 ### Tag Hierarchy
@@ -135,8 +137,9 @@ hunter/
 
 content/
 ├── brief             # all content briefs
+├── from-the-wild     # wild-scan quote indices
 ├── series/
-│   └── {slug}        # e.g., memory-gap, building-in-public
+│   └── {slug}        # e.g., memory-gap, building-in-public, from-the-wild
 ├── channel/
 │   ├── linkedin
 │   ├── blog
@@ -218,7 +221,12 @@ signal-scan ──→ decision-log ──→ persona-extract ──→ swot-anal
                                         └──→ content-planner
                                                     │
                                               (reads both pipelines
-                                               + GitHub + buildlog)
+                                               + GitHub + buildlog
+                                               + wild-scan indices)
+
+wild-scan ──→ Writing/From-The-Wild/ (quote indices)
+         └──→ Writing/Content-Briefs/ (series: "From the Wild")
+              └──→ content-planner picks these up
 ```
 
 Every skill:

--- a/skills/custom/inline-svg-architecture-diagrams/SKILL.md
+++ b/skills/custom/inline-svg-architecture-diagrams/SKILL.md
@@ -552,7 +552,247 @@ These are dark-mode defaults. The point of CSS variables is that light-mode them
 
 ---
 
+## Style Variant: Portfolio Hand-Drawn
+
+> External `.svg` files with a hand-drawn, sketchy aesthetic. Transparent background, Caveat cursive font, wobbly path-based shapes, `feTurbulence` displacement filter. No CSS variables, no grid backgrounds, no build steps.
+
+### When to Use This Style
+
+- Portfolio articles, blog posts, writing collections
+- Diagrams that sit inside prose content (not dashboards or app UIs)
+- Visual storytelling where warmth and approachability matter
+- Any context where the rigid CSS-variable system feels too "enterprise"
+
+### Color Palette (Hardcoded — No CSS Variables)
+
+| Role | Value | Usage |
+|------|-------|-------|
+| Primary text | `#e0e0e0` | Labels, titles, main content |
+| Muted text | `#888888` | Captions, annotations, sub-labels |
+| Accent | `rgb(168,85,247)` | Borders, highlights, numbered callouts, animated elements |
+| Accent fill | `rgba(168,85,247,0.08)` | Box backgrounds (subtle) |
+| Accent fill (glow) | `rgba(168,85,247,0.12-0.14)` | Highlighted/glowing box backgrounds |
+| Success | `#4ade80` | Accept, positive signals |
+| Danger | `#f87171` | Reject, negative signals, warnings |
+| Background | transparent | SVG has no background — inherits from page |
+
+### Typography
+
+All text uses:
+```
+font-family="'Caveat', 'Comic Sans MS', cursive"
+```
+
+No monospace. No sans-serif. Everything is hand-drawn cursive.
+
+| Element | Size | Weight | Fill |
+|---------|------|--------|------|
+| Diagram title | 20-22px | bold | `#e0e0e0` |
+| Section headers / labels | 15px | bold | `#e0e0e0` |
+| Body text / descriptions | 12-13px | normal | `#888888` |
+| Annotations / captions | 10-11px | normal | `#888888` |
+| Accent annotations | 12px | normal | `rgb(168,85,247)` |
+
+### Filter Definitions
+
+**Roughen filter** — Applies to box paths for hand-drawn wobble:
+```xml
+<filter id="roughen" x="-2%" y="-2%" width="104%" height="104%">
+  <feTurbulence type="turbulence" baseFrequency="0.03" numOctaves="2" result="noise" seed="3"/>
+  <feDisplacementMap in="SourceGraphic" in2="noise" scale="1.2" xChannelSelector="R" yChannelSelector="G"/>
+</filter>
+```
+
+Vary the `seed` value (1-10) per diagram for different wobble patterns. Keep `scale` between 1.0-1.2.
+
+**Glow filter** — For emphasized/highlighted elements:
+```xml
+<filter id="glow">
+  <feGaussianBlur stdDeviation="3" result="blur"/>
+  <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+</filter>
+```
+
+### Arrow Markers
+
+Open chevron style — not filled triangles. Stroke-only, rounded caps:
+```xml
+<marker id="arrow" viewBox="0 0 12 10" refX="10" refY="5"
+        markerWidth="8" markerHeight="6" orient="auto-start-reverse"
+        fill="none" stroke="#e0e0e0" stroke-width="1.5"
+        stroke-linecap="round" stroke-linejoin="round">
+  <path d="M 1,1 L 10,5 L 1,9"/>
+</marker>
+```
+
+Color variants (same shape, different stroke):
+- `id="arrow-purple"` → `stroke="rgb(168,85,247)"`
+- `id="arrow-green"` → `stroke="#4ade80"`
+- `id="arrow-red"` → `stroke="#f87171"`
+
+### Wobbly Box Technique
+
+Use `<path>` with slightly irregular coordinates instead of `<rect>`:
+
+```xml
+<!-- WRONG: rigid rectangle -->
+<rect x="132" y="68" width="430" height="60" rx="8"/>
+
+<!-- RIGHT: organic wobbly path -->
+<path d="M 132,68 C 230,65 430,71 562,67
+         C 565,85 563,105 565,128
+         C 430,131 230,127 132,131
+         C 129,113 131,87 129,68"
+      stroke="rgb(168,85,247)" stroke-width="2" fill="rgba(168,85,247,0.08)"
+      stroke-linecap="round" stroke-linejoin="round"/>
+```
+
+Key technique: Each control point varies **±3px** from the "perfect" rectangle coordinates. The `C` (cubic bezier) commands create subtle organic curves. Always use `stroke-linecap="round"` and `stroke-linejoin="round"`.
+
+### Organic Touches
+
+These details make the difference between "SVG diagram" and "hand-drawn sketch":
+
+- **Slight rotation transforms**: `transform="rotate(-0.4, cx, cy)"` on groups — vary between ±0.3° and ±0.8°
+- **Title underline**: Wobbly `<path>` under title text, not a `<line>` — slightly off-center, accent color at 0.5 opacity
+- **Decorative margin sketches**: Tiny illustrations at 0.25-0.35 opacity (mini knowledge graphs, beta curves, coffee cups, etc.)
+- **Numbered callouts**: Purple filled circles with white bold numbers
+- **Animated dashed lines**: `stroke-dasharray="8 5"` with `<animate>` on `stroke-dashoffset`
+- **Bottom caption**: Muted italic-feeling observation, `font-size="11"`, `fill="#888888"`, `opacity="0.6"`
+
+### Numbered Callout Pattern
+
+```xml
+<circle cx="108" cy="82" r="14" fill="rgb(168,85,247)" stroke="none" opacity="0.9"/>
+<text x="108" y="87" text-anchor="middle"
+      font-family="'Caveat', 'Comic Sans MS', cursive"
+      font-size="14" fill="white" font-weight="bold">1</text>
+```
+
+### Standard Layout
+
+- `viewBox="0 0 672 {height}"` — 672px wide to match content column
+- External `.svg` files in `public/diagrams/`, referenced via `<img src="/diagrams/name.svg">`
+- Include `xmlns="http://www.w3.org/2000/svg"` on root `<svg>` element
+- No `width`/`height` attributes — let the img container control sizing
+
+### Quality Checklist (Hand-Drawn Style)
+
+- [ ] All colors hardcoded (zero CSS variables)
+- [ ] Font is Caveat/cursive throughout — no monospace, no sans-serif
+- [ ] Boxes use `<path>` not `<rect>` — visibly wobbly
+- [ ] `roughen` filter applied to box paths where appropriate
+- [ ] Background is transparent (no grid pattern, no fill on root)
+- [ ] At least one decorative margin sketch (graph, curve, icon)
+- [ ] Slight rotation transforms on groups (±0.3° to ±0.8°)
+- [ ] Title has wobbly underline path
+- [ ] Animations are subtle and loop smoothly
+- [ ] Caption text at bottom in muted `#888888` at reduced opacity
+
+### Full Example: Feedback Loop Diagram
+
+From `portfolio/public/diagrams/feedback-loop.svg` — a 6-step vertical flow with feedback arc, decorative margin sketches, and accent annotations:
+
+```xml
+<svg viewBox="0 0 672 920" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <filter id="roughen" x="-2%" y="-2%" width="104%" height="104%">
+      <feTurbulence type="turbulence" baseFrequency="0.03" numOctaves="2" result="noise" seed="3"/>
+      <feDisplacementMap in="SourceGraphic" in2="noise" scale="1.2" xChannelSelector="R" yChannelSelector="G"/>
+    </filter>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="3" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <marker id="arrow" viewBox="0 0 12 10" refX="10" refY="5"
+            markerWidth="8" markerHeight="6" orient="auto-start-reverse"
+            fill="none" stroke="#e0e0e0" stroke-width="1.5"
+            stroke-linecap="round" stroke-linejoin="round">
+      <path d="M 1,1 L 10,5 L 1,9"/>
+    </marker>
+    <marker id="arrow-purple" viewBox="0 0 12 10" refX="10" refY="5"
+            markerWidth="8" markerHeight="6" orient="auto-start-reverse"
+            fill="none" stroke="rgb(168,85,247)" stroke-width="1.5"
+            stroke-linecap="round" stroke-linejoin="round">
+      <path d="M 1,1 L 10,5 L 1,9"/>
+    </marker>
+  </defs>
+
+  <!-- TITLE with wobbly underline -->
+  <text x="336" y="38" text-anchor="middle"
+        font-family="'Segoe Print', 'Comic Sans MS', 'Caveat', cursive"
+        font-size="22" fill="#e0e0e0" font-weight="bold"
+        transform="rotate(-0.6, 336, 38)">
+    Qortex Feedback Loop
+  </text>
+  <path d="M 182,46 C 230,48 340,44 490,47"
+        stroke="rgb(168,85,247)" stroke-width="1.5" fill="none"
+        stroke-linecap="round" opacity="0.6"/>
+
+  <!-- STEP: Numbered callout + wobbly box + labels -->
+  <g transform="rotate(-0.4, 336, 100)">
+    <circle cx="108" cy="82" r="14" fill="rgb(168,85,247)" stroke="none" opacity="0.9"/>
+    <text x="108" y="87" text-anchor="middle"
+          font-family="'Segoe Print', 'Comic Sans MS', cursive"
+          font-size="14" fill="white" font-weight="bold">1</text>
+
+    <path d="M 132,68 C 230,65 430,71 562,67
+             C 565,85 563,105 565,128
+             C 430,131 230,127 132,131
+             C 129,113 131,87 129,68"
+          stroke="rgb(168,85,247)" stroke-width="2" fill="rgba(168,85,247,0.08)"
+          stroke-linecap="round" stroke-linejoin="round"/>
+
+    <text x="348" y="92" text-anchor="middle"
+          font-family="'Segoe Print', 'Comic Sans MS', cursive"
+          font-size="15" fill="#e0e0e0" font-weight="bold">Query Arrives</text>
+    <text x="348" y="114" text-anchor="middle"
+          font-family="'Segoe Print', 'Comic Sans MS', cursive"
+          font-size="12" fill="#888888">vector similarity finds seed concepts</text>
+  </g>
+
+  <!-- ARROW between steps -->
+  <path d="M 336,134 C 338,150 334,162 336,176"
+        stroke="#e0e0e0" stroke-width="2" fill="none"
+        stroke-linecap="round" marker-end="url(#arrow)"/>
+
+  <!-- ... more steps ... -->
+
+  <!-- FEEDBACK ARC: loops back from bottom to top -->
+  <path d="M 128,790 C 78,788 42,760 38,700
+           C 34,580 36,400 36,260
+           C 36,160 42,100 62,82
+           C 72,73 90,70 108,68"
+        stroke="rgb(168,85,247)" stroke-width="2.2" fill="none"
+        stroke-linecap="round" stroke-dasharray="8 5"
+        opacity="0.7" filter="url(#glow)"
+        marker-end="url(#arrow-purple)"/>
+
+  <!-- DECORATIVE: Mini knowledge graph in margin -->
+  <g transform="translate(580, 210)" opacity="0.35">
+    <circle cx="0" cy="0" r="5" fill="rgb(168,85,247)" stroke="#e0e0e0" stroke-width="1"/>
+    <circle cx="30" cy="-20" r="4" fill="rgb(168,85,247)" stroke="#e0e0e0" stroke-width="1"/>
+    <circle cx="35" cy="15" r="4" fill="rgb(168,85,247)" stroke="#e0e0e0" stroke-width="1"/>
+    <path d="M 4,0 C 15,-8 22,-16 27,-18" stroke="#e0e0e0" stroke-width="0.8" fill="none"/>
+    <path d="M 4,3 C 15,8 28,12 32,14" stroke="#e0e0e0" stroke-width="0.8" fill="none"/>
+  </g>
+
+  <!-- BOTTOM CAPTION -->
+  <text x="336" y="910" text-anchor="middle"
+        font-family="'Segoe Print', 'Comic Sans MS', cursive"
+        font-size="11" fill="#888888" opacity="0.6">
+    each cycle sharpens the graph — good paths get stronger, bad paths decay
+  </text>
+</svg>
+```
+
+Also see: `portfolio/public/diagrams/broken-loop-vs-pipeline.svg`, `parking-lot-timeline.svg`, `pipeline-architecture.svg`, `ppr-traversal.svg`, `convergence-plot.svg`
+
+---
+
 ## Reference Implementation
+
+### Design System Style (CSS Variables)
 
 See `portfolio/src/pages/lab.astro` — Five-layer agent architecture diagram with:
 - 5 vertically stacked layers with mini-icons
@@ -563,3 +803,13 @@ See `portfolio/src/pages/lab.astro` — Five-layer agent architecture diagram wi
 - Glow filter + pulse ring on the core (Learning) layer
 - Clickable layers linking to project doc sites
 - Full hover interaction CSS
+
+### Hand-Drawn Style (Hardcoded Colors)
+
+See `portfolio/public/diagrams/` — External SVG files for blog articles:
+- `feedback-loop.svg` — 6-step vertical flow with feedback arc and margin decorations
+- `ppr-traversal.svg` — Animated graph traversal with CSS keyframes
+- `convergence-plot.svg` — Hand-drawn chart with wobbly axes and data curves
+- `broken-loop-vs-pipeline.svg` — Side-by-side comparison with animated loop
+- `pipeline-architecture.svg` — Numbered pipeline stages with I/O annotations
+- `parking-lot-timeline.svg` — Horizontal timeline with alternating above/below labels

--- a/skills/custom/pitch/SKILL.md
+++ b/skills/custom/pitch/SKILL.md
@@ -83,6 +83,7 @@ Step 2: Check what is already deployed (launchpad branch? seeds exist? kanban ex
     |
 Step 3: Deploy missing artifacts only
     |    ├── Phase 2.4: Launch posts → Obsidian content seeds
+    |    ├── Phase 3e: Landing page copy → index.html on launchpad branch
     |    ├── Phase 4.6: Email sequence → individual files on launchpad branch
     |    ├── Phase 5.6: Launch checklist → Obsidian kanban
     |    └── Phase 7.6: Kill criteria → Obsidian Tasks on pitch doc
@@ -98,6 +99,7 @@ The deploy-only mode reads the pitch markdown and locates content by H2 section 
 
 | Pitch Section | Header (either format) | Parser | Deploy Phase |
 |---|---|---|---|
+| Landing Page Copy | `## Landing Page Copy` or `## Phase 1: Landing Page Copy` | Read all subsections (### Headline through ### Call to Action) and pass to Phase 3e HTML generator | 3e (index.html on launchpad branch) |
 | Launch Posts | `## Launch Posts` or `## Phase 2: Launch Posts` | Split by `### {Platform}: {Title}`, `### Reddit r/{sub} Post`, or `### Twitter/X Thread` | 2.4 (Obsidian seeds) |
 | Email Sequence | `## Email Sequence` or `## Phase 4: Email Sequence` | Split by `### Email {N}: {Subject} (Day {N})` | 4.6 (individual files) |
 | Launch Checklist | `## Launch Checklist` or `## Phase 5: Launch Checklist` | Split by `### Pre-Launch`, `### Launch Day`, `### Week 1`, `### Ongoing Cadence`, `### Month 2-3 Growth` | 5.6 (Obsidian kanban) |
@@ -110,9 +112,10 @@ The deploy-only mode reads the pitch markdown and locates content by H2 section 
 Before deploying each artifact:
 
 1. **Content seeds** (Phase 2.4): Check if `{vault}/Writing/Content-Briefs/{product-slug}-{platform}-seed-*.md` already exists. If yes, skip and warn (or append under `## Update: {timestamp}` per conventions).
-2. **Email files** (Phase 4.6): Check if `emails/` directory exists on the launchpad branch. If yes, skip and warn. If the branch does not exist, warn that Phase 3d (launchpad branch creation) should run first.
-3. **Kanban** (Phase 5.6): Check if `{vault}/Admin/Product-Discovery/Pitches/{product-slug}-launch-checklist.kanban.md` exists. If yes, skip and warn.
-4. **Review reminders** (Phase 7.6): Check if the pitch markdown already has a `## Review Reminders` section. If yes, skip and warn.
+2. **Landing page HTML** (Phase 3e): Check if `index.html` exists on the launchpad branch root. If yes, skip and warn. If the branch does not exist, warn that Phase 3d (launchpad branch creation) should run first.
+3. **Email files** (Phase 4.6): Check if `emails/` directory exists on the launchpad branch. If yes, skip and warn. If the branch does not exist, warn that Phase 3d (launchpad branch creation) should run first.
+4. **Kanban** (Phase 5.6): Check if `{vault}/Admin/Product-Discovery/Pitches/{product-slug}-launch-checklist.kanban.md` exists. If yes, skip and warn.
+5. **Review reminders** (Phase 7.6): Check if the pitch markdown already has a `## Review Reminders` section. If yes, skip and warn.
 
 ### Deploy-Only Output
 
@@ -122,6 +125,7 @@ Returns a deployment report:
 {
   "pitch_ref": "devops-decision-kit-pitch-2026-02-08",
   "deployed": {
+    "landing_page_html": "index.html (on {product-slug} branch)",
     "content_seeds": ["path/to/seed-1.md", "path/to/seed-2.md"],
     "email_files": ["emails/email-1-welcome.md", ...],
     "kanban": "path/to/launch-checklist.kanban.md",
@@ -236,7 +240,7 @@ Phase 1: Landing Page Copy (complete, ready to paste)
     |
 Phase 2: Launch Posts (platform-specific, ready to publish)
     |
-Phase 3: GitHub Product README (Phase 3a: product structure + Phase 3b: README copy)
+Phase 3: GitHub Product Repo (3a: structure + 3b: README + 3c: hero + 3d: branch/PR + 3e: landing page HTML)
     |
 Phase 4: Email Sequence (3-5 emails, post-purchase nurture)
     |
@@ -574,6 +578,138 @@ After generating the README and product structure, deploy to the `launchpad` rep
    - The PR is the operator's review surface for line-by-line feedback
 
 The PR stays open until the operator reviews and merges. The operator can comment on specific files, and the agent can address feedback in subsequent commits to the same branch.
+
+### Phase 3e: Landing Page HTML
+
+After the launchpad branch exists (Phase 3d), generate a complete, single-file `index.html` from the Phase 1 landing page copy and commit it to the branch root. Vercel auto-deploys every branch, so this file immediately becomes a live landing page at the branch preview URL.
+
+**This phase converts Phase 1 copy into a deployable page. It does NOT rewrite copy.** The HTML is a faithful rendering of the Phase 1 output. If the copy needs revision, revise Phase 1 first, then re-run Phase 3e.
+
+#### 3e.1 Design System
+
+Generate a single `<style>` tag inside `<head>` with these design tokens and components. No external CSS, no JavaScript frameworks, no CDN links. The page must work as a standalone file with zero dependencies.
+
+**Color tokens (CSS custom properties on `:root`):**
+
+| Token | Value | Usage |
+|-------|-------|-------|
+| `--bg` | `#0d1117` | Page background |
+| `--surface` | `#161b22` | Cards, blockquotes, FAQ panels |
+| `--border` | `#30363d` | All borders |
+| `--text` | `#e6edf3` | Primary text |
+| `--text-muted` | `#8b949e` | Secondary text, descriptions, citations |
+| `--accent` | `#58a6ff` | Links, module names, interactive highlights |
+| `--accent-hover` | `#79c0ff` | Link hover state |
+| `--green` | `#3fb950` | Primary CTA buttons, "after" cards, checkmarks |
+| `--orange` | `#d29922` | Warning or emphasis accents |
+| `--red` | `#f85149` | "Before" cards, problem emphasis |
+
+**Typography:**
+- Font stack: `-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif`
+- Line height: `1.6`
+- `-webkit-font-smoothing: antialiased`
+- Hero h1: `2.8rem`, weight `800`, letter-spacing `-0.02em`
+- Section h2: `1.8rem`, weight `700`, letter-spacing `-0.01em`
+- Body text: `1.05rem`, color `var(--text-muted)`
+
+**Layout:**
+- `.container`: max-width `720px`, centered, `24px` horizontal padding
+- Sections separated by `border-top: 1px solid var(--border)` with `60px` vertical padding
+- Mobile breakpoint at `640px`: reduce h1 to `2rem`, container padding to `16px`, collapse grids to single column
+
+#### 3e.2 Section-to-HTML Mapping
+
+Each Phase 1 section maps to a semantic HTML block. Generate every section that Phase 1 produced. If a section is empty or was not generated in Phase 1, skip it -- do not generate placeholder content.
+
+| Phase 1 Section | HTML Element | Key Styling |
+|-----------------|-------------|-------------|
+| **Headline + Subheadline** | `<header class="hero">` containing `<h1>` and `<p class="sub">` | Centered, `80px` top padding, `60px` bottom |
+| **Primary + Secondary CTA** | `<div class="cta-group">` with `<a class="btn btn-primary">` and `<a class="btn btn-secondary">` | Flex row, centered, wraps on mobile. Primary: green bg, black text. Secondary: surface bg with border. |
+| **Problem Section** | `<section>` with prose `<p>` tags and `<blockquote>` elements | Blockquotes: `3px` left border in accent color, surface bg, `6px` right border-radius. Attribution in `<cite>`. |
+| **Solution / Before-After** | `<section>` with `.before-after` grid (`1fr 1fr`) containing `.ba-card.before` and `.ba-card.after` | Before: red-tinted border/heading. After: green-tinted. Collapse to single column on mobile. |
+| **How It Works** | `<ol class="steps">` with `<li>` items | CSS counter with numbered circles (accent text, surface bg) positioned left of each step. |
+| **What's Inside / Modules** | `<table class="modules-table">` with `<thead>` and `<tbody>` | First column: accent color, `600` weight, no-wrap. Last column: muted, smaller. Hover: surface bg. |
+| **Social Proof / Credibility** | `<section>` with `<div class="cred">` | Surface bg, bordered card, `28px` padding. |
+| **Pricing** | `<section>` with `.pricing-cards` grid (`1fr 1fr`) | Each card: surface bg, bordered. Featured: green border. Price: `2rem` weight `800`. Checkmark list via `li::before`. |
+| **Comparison List** | `<ul class="compare-list">` | Flexbox rows, space-between, border-bottom separator. |
+| **FAQ** | `<details>` elements with `<summary>` and `<div>` | Surface bg, bordered, `6px` radius. Custom marker: `+`/`−`. No default webkit marker. |
+| **Final CTA** | `<div class="final-cta">` with h2 + `<p>` + `.cta-group` | Centered, `60px` padding, mirrors hero CTA. |
+| **Footer** | `<footer>` | Centered, muted, `40px` padding. Links to GitHub and author. |
+
+#### 3e.3 Open Graph and Meta Tags
+
+Generate in `<head>`:
+
+```html
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{Product Name} — {Headline (truncated to ~60 chars)}</title>
+<meta name="description" content="{Subheadline, max 160 chars}">
+<meta property="og:title" content="{Product Name} — {Headline}">
+<meta property="og:description" content="{Subheadline}">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://launchpad-git-{product-slug}-kwayet-fs-projects.vercel.app">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="{Product Name} — {Headline}">
+<meta name="twitter:description" content="{Subheadline}">
+```
+
+If a hero image was generated in Phase 3c, add `og:image` and `twitter:image` tags pointing to `/hero.png`. If not, omit them rather than linking to a nonexistent file.
+
+#### 3e.4 CTA Link Targets
+
+| CTA | Link Target | Fallback |
+|-----|------------|----------|
+| Primary ("Clone the Repo", "Get the Kit") | `https://github.com/Peleke/launchpad/tree/{product-slug}` | `#` with `<!-- TODO: update link -->` |
+| Secondary ("Join the Community") | Skool community URL if known | `#community` anchor to pricing section |
+| Email signup | ConvertKit/Buttondown URL if known | `#` with `<!-- TODO: add signup link -->` |
+
+Every placeholder link must have an HTML comment explaining what URL to replace it with.
+
+#### 3e.5 Content Fidelity Rules
+
+- **Do not rewrite copy.** The HTML renders Phase 1 copy verbatim.
+- **Typographic entities required.** Straight quotes → curly (`&ldquo;`/`&rdquo;`, `&lsquo;`/`&rsquo;`), hyphens → em-dashes (`&mdash;`), three dots → ellipsis (`&hellip;`).
+- **Preserve all persona quotes.** Every blockquote must include quote text in `<p>` and attribution in `<cite>` with em-dash prefix.
+- **Preserve the module/feature table exactly.** Same columns, same rows as Phase 1.
+- **Preserve all FAQ items.** Each FAQ becomes one `<details>/<summary>` element. Do not merge or split.
+
+#### 3e.6 Responsive Behavior
+
+The `@media (max-width: 640px)` breakpoint must:
+- Reduce hero h1 to `2rem`, subtitle to `1.05rem`
+- Collapse `.before-after` and `.pricing-cards` grids to single column
+- Tighten module table padding (`10px 8px`) and font (`0.85rem`)
+- Reduce container padding to `16px`
+- No horizontal scrolling at any viewport width down to `320px`
+
+#### 3e.7 File Output
+
+Write `index.html` to the launchpad product branch root alongside `README.md`. If Phase 3d already ran and the branch exists, commit and push. If the PR is already open, this becomes an additional commit on the same PR.
+
+#### 3e.8 Validation Checklist
+
+- [ ] Valid HTML5 (`<!DOCTYPE html>`, `<html lang="en">`)
+- [ ] All CSS inline in a single `<style>` tag -- no external stylesheets
+- [ ] No JavaScript -- pure HTML + CSS
+- [ ] No external dependencies -- no CDN, no Google Fonts, no analytics
+- [ ] All Phase 1 sections present (unless empty in Phase 1)
+- [ ] All persona quotes as `<blockquote>` with `<cite>`
+- [ ] Module/feature table matches Phase 1 exactly
+- [ ] All FAQs as `<details>/<summary>`
+- [ ] Both CTAs in hero and final CTA sections
+- [ ] Open Graph meta tags with correct product name and description
+- [ ] Mobile responsive at 640px (no horizontal scroll, grids collapse)
+- [ ] All placeholder links have HTML comments
+- [ ] Typographic entities used throughout
+- [ ] File under 30KB
+
+#### Landing Page HTML Rules
+
+- Page must render correctly as local file (`file://`) AND served by Vercel
+- Page must look complete without hero image (no broken image placeholder)
+- Semantic HTML: `<header>`, `<section>`, `<footer>`, `<blockquote>`, `<details>`, `<summary>`, `<table>`, `<cite>`
+- Dark theme is non-negotiable. All launchpad products use the same visual identity.
 
 ---
 
@@ -1030,6 +1166,16 @@ signal_scan_ref: "{signal-scan-slug}"
 
 ---
 
+## Landing Page HTML
+
+**File**: `index.html` (on `{product-slug}` branch)
+**Preview URL**: [{vercel-preview-url}]({vercel-preview-url})
+**Sections rendered**: [list of sections from Phase 1 that were converted to HTML]
+**Hero image in OG tags**: Yes/No
+**File size**: {N} bytes
+
+---
+
 ## Email Sequence
 
 ### Email 1: [Subject Line] (Day 0)
@@ -1126,6 +1272,13 @@ signal_scan_ref: "{signal-scan-slug}"
 - `emails/` directory with individual email files from Phase 4.6
 - PR opened against `main` for operator review (Phase 3d)
 
+#### 3b. Landing Page HTML: `index.html` on launchpad branch root
+- Single-file HTML landing page generated from Phase 1 copy (Phase 3e)
+- Dark theme, mobile responsive, zero dependencies
+- Open Graph meta tags for social sharing
+- Immediately deployable via Vercel branch preview
+- Preview URL: `https://launchpad-git-{product-slug}-kwayet-fs-projects.vercel.app`
+
 #### 4. Content Seeds: `{vault}/Writing/Content-Briefs/{product-slug}-{platform}-seed-{YYYY-MM-DD}.md`
 - One file per launch post (Phase 2.4)
 - Frontmatter: `type: content-brief`, `status: backlog`, platform tag
@@ -1219,6 +1372,10 @@ Run this checklist before delivering the pitch:
 - [ ] Markdown output has correct frontmatter (type: pitch, date, status: draft, tags, all refs)
 - [ ] Both files are saved to vault `Admin/Product-Discovery/Pitches/`
 - [ ] Launchpad branch created with product structure, README, hero image, and emails/
+- [ ] Landing page index.html generated from Phase 1 copy and committed to launchpad branch
+- [ ] Landing page renders at mobile (640px) and desktop, no horizontal scroll
+- [ ] Landing page has zero external dependencies (no CDN, no JS, no external CSS)
+- [ ] Open Graph meta tags present with product name, description, and hero image URL (if hero exists)
 - [ ] PR opened against launchpad main with review checklist
 - [ ] Content seeds written to `Writing/Content-Briefs/` with correct frontmatter
 - [ ] Launch checklist written as Obsidian kanban with dated tasks

--- a/skills/custom/pitch/references/output-schema.json
+++ b/skills/custom/pitch/references/output-schema.json
@@ -12,6 +12,7 @@
     "landing_page",
     "launch_posts",
     "github_readme",
+    "landing_page_html",
     "email_sequence",
     "launch_checklist",
     "ab_test_spec",
@@ -230,6 +231,50 @@
         "readme_content": {
           "type": "string",
           "description": "The full README.md content. Includes hero section, product structure preview, decision framework preview (the free 80%), CTA sections, social proof, contributing, and license."
+        }
+      }
+    },
+    "landing_page_html": {
+      "type": "object",
+      "description": "Metadata about the generated landing page HTML file. The actual HTML is written to the launchpad branch, not embedded in the JSON output.",
+      "required": ["file_path", "vercel_preview_url", "sections_rendered", "has_hero_image"],
+      "properties": {
+        "file_path": {
+          "type": "string",
+          "description": "Path to index.html on the launchpad branch (always 'index.html' at branch root)"
+        },
+        "vercel_preview_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "The Vercel branch preview URL where the page is live"
+        },
+        "sections_rendered": {
+          "type": "array",
+          "description": "List of Phase 1 sections that were rendered into HTML",
+          "items": {
+            "type": "string",
+            "enum": [
+              "hero",
+              "problem",
+              "solution_before_after",
+              "how_it_works",
+              "modules_table",
+              "credibility",
+              "pricing",
+              "comparison",
+              "faq",
+              "final_cta",
+              "footer"
+            ]
+          }
+        },
+        "has_hero_image": {
+          "type": "boolean",
+          "description": "Whether og:image and twitter:image meta tags reference an actual hero.png"
+        },
+        "file_size_bytes": {
+          "type": "integer",
+          "description": "Size of the generated index.html in bytes. Should be under 30720 (30KB)."
         }
       }
     },


### PR DESCRIPTION
## Summary

- Update `_conventions.md` with minor fixes
- Expand `inline-svg-architecture-diagrams` skill
- Add pitch output schema (`references/output-schema.json`)
- Expand pitch skill with additional conventions

## Test plan

- [ ] Verify conventions and schemas parse correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)